### PR TITLE
ESSIFI-161 - @Context & credentialSchema both should be checked

### DIFF
--- a/lib/evaluation/handlers/uriEvaluationHandler.ts
+++ b/lib/evaluation/handlers/uriEvaluationHandler.ts
@@ -101,7 +101,7 @@ export class UriEvaluationHandler extends AbstractEvaluationHandler {
     result.status = Status.INFO;
     result.message = PEMessages.URI_EVALUATION_PASSED;
     result.payload = {
-      vcContextUri: vc.getContext(),
+      vcContext: vc.getContext(),
       vcCredentialSchema: vc.getCredentialSchema(),
       inputDescriptorsUris,
     };
@@ -118,7 +118,7 @@ export class UriEvaluationHandler extends AbstractEvaluationHandler {
     result.status = Status.ERROR;
     result.message = PEMessages.URI_EVALUATION_DIDNT_PASS;
     result.payload = {
-      vcContextUri: vc.getContext(),
+      vcContext: vc.getContext(),
       vcCredentialSchema: vc.getCredentialSchema(),
       inputDescriptorsUris,
     };

--- a/lib/evaluation/handlers/uriEvaluationHandler.ts
+++ b/lib/evaluation/handlers/uriEvaluationHandler.ts
@@ -5,7 +5,12 @@ import { nanoid } from 'nanoid';
 import { Status } from '../../ConstraintUtils';
 import { InternalVerifiableCredential } from '../../types';
 import PEMessages from '../../types/Messages';
-import { InternalPresentationDefinition, InternalPresentationDefinitionV1, PEVersion } from '../../types/SSI.types';
+import {
+  CredentialSchema,
+  InternalPresentationDefinition,
+  InternalPresentationDefinitionV1,
+  PEVersion,
+} from '../../types/SSI.types';
 import { EvaluationClient } from '../evaluationClient';
 import { HandlerCheckResult } from '../handlerCheckResult';
 
@@ -25,7 +30,8 @@ export class UriEvaluationHandler extends AbstractEvaluationHandler {
     (<InternalPresentationDefinitionV1>d).input_descriptors.forEach((inDesc: InputDescriptorV1, i: number) => {
       const uris: string[] = d.getVersion() !== PEVersion.v2 ? inDesc.schema.map((so) => so.uri) : [];
       vcs.forEach((vc: InternalVerifiableCredential, j: number) => {
-        this.evaluateUris(vc.getContext(), uris, i, j, d.getVersion());
+        const vcUris: string[] = UriEvaluationHandler.fetchVcUris(vc);
+        this.evaluateUris(vcUris, uris, i, j, d.getVersion());
       });
     });
     const descriptorMap: Descriptor[] = this.getResults()
@@ -46,7 +52,7 @@ export class UriEvaluationHandler extends AbstractEvaluationHandler {
   }
 
   private evaluateUris(
-    verifiableCredentialUris: string[] | string,
+    verifiableCredentialUris: string[],
     inputDescriptorsUris: string[],
     idIdx: number,
     vcIdx: number,
@@ -54,15 +60,8 @@ export class UriEvaluationHandler extends AbstractEvaluationHandler {
   ): void {
     let hasAnyMatch = false;
     if (pdVersion === PEVersion.v1) {
-      let vcUris: string[] = [];
-      if (Array.isArray(verifiableCredentialUris)) {
-        vcUris = [...verifiableCredentialUris];
-      } else {
-        vcUris = [verifiableCredentialUris];
-      }
-
       for (let i = 0; i < verifiableCredentialUris.length; i++) {
-        if (inputDescriptorsUris.find((el) => el === vcUris[i]) != undefined) {
+        if (inputDescriptorsUris.find((el) => el === verifiableCredentialUris[i]) != undefined) {
           hasAnyMatch = true;
         }
       }
@@ -80,6 +79,21 @@ export class UriEvaluationHandler extends AbstractEvaluationHandler {
     }
   }
 
+  private static fetchVcUris(vc: InternalVerifiableCredential) {
+    const uris: string[] = [];
+    if (Array.isArray(vc.getContext())) {
+      uris.push(...vc.getContext());
+    } else {
+      uris.push(<string>vc.getContext());
+    }
+    if (Array.isArray(vc.getCredentialSchema()) && (vc.getCredentialSchema() as CredentialSchema[]).length > 0) {
+      (vc.getCredentialSchema() as CredentialSchema[]).forEach((element) => uris.push(element.id));
+    } else if (vc.getCredentialSchema()) {
+      uris.push((vc.getCredentialSchema() as CredentialSchema).id);
+    }
+    return uris;
+  }
+
   private createSuccessResultObject(
     verifiableCredentialUris: string[] | string,
     inputDescriptorsUris: string[],
@@ -89,7 +103,7 @@ export class UriEvaluationHandler extends AbstractEvaluationHandler {
     const result: HandlerCheckResult = this.createResult(idIdx, vcIdx);
     result.status = Status.INFO;
     result.message = PEMessages.URI_EVALUATION_PASSED;
-    result.payload = { presentationDefinitionUris: verifiableCredentialUris, inputDescriptorsUris };
+    result.payload = { verifiableCredentialUris, inputDescriptorsUris };
     return result;
   }
 
@@ -102,10 +116,9 @@ export class UriEvaluationHandler extends AbstractEvaluationHandler {
     const result = this.createResult(idIdx, vcIdx);
     result.status = Status.ERROR;
     result.message = PEMessages.URI_EVALUATION_DIDNT_PASS;
-    result.payload = { presentationDefinitionUris: verifiableCredentialUris, inputDescriptorsUris };
+    result.payload = { verifiableCredentialUris, inputDescriptorsUris };
     return result;
   }
-
   private createResult(idIdx: number, vcIdx: number): HandlerCheckResult {
     return {
       input_descriptor_path: `$.input_descriptors[${idIdx}]`,

--- a/lib/types/SSI.types.ts
+++ b/lib/types/SSI.types.ts
@@ -14,6 +14,11 @@ export interface CredentialSubject {
   [x: string]: unknown;
 }
 
+export interface CredentialSchema {
+  id: string;
+  type: string;
+}
+
 export enum ProofType {
   Ed25519Signature2018 = 'Ed25519Signature2018',
   Ed25519Signature2020 = 'Ed25519Signature2020',
@@ -69,6 +74,8 @@ export interface InternalCredential {
 
   getContext(): string[] | string;
 
+  getCredentialSchema(): CredentialSchema | CredentialSchema[];
+
   getExpirationDate(): string | undefined;
 
   getId(): string | undefined;
@@ -88,6 +95,7 @@ export class InternalCredentialBase {
   '@context': string[] | string;
   credentialStatus?: CredentialStatus;
   credentialSubject: CredentialSubject;
+  credentialSchema?: CredentialSchema | CredentialSchema[];
   description?: string;
   expirationDate?: string;
   id: string;
@@ -143,6 +151,13 @@ export class InternalCredentialJWT implements InternalCredential {
     return this.vc['@context'];
   }
 
+  getCredentialSchema(): CredentialSchema | CredentialSchema[] {
+    if (this.vc.credentialSchema) {
+      return this.vc.credentialSchema;
+    }
+    return [];
+  }
+
   getType(): string {
     return 'jwt';
   }
@@ -179,6 +194,13 @@ export class InternalCredentialJsonLD extends InternalCredentialBase implements 
 
   getContext(): string[] | string {
     return this['@context'];
+  }
+
+  getCredentialSchema(): CredentialSchema[] | CredentialSchema {
+    if (this.credentialSchema) {
+      return this.credentialSchema;
+    }
+    return [];
   }
 
   getType(): string {
@@ -255,6 +277,7 @@ export interface Credential {
   issuer?: unknown;
   name?: string;
   type?: string[];
+
   // JSON-LD related fields end
 
   [x: string]: unknown;

--- a/test/evaluation/EvaluationClientWrapperData.ts
+++ b/test/evaluation/EvaluationClientWrapperData.ts
@@ -18,10 +18,8 @@ export class EvaluationClientWrapperData {
       message: PEMessages.URI_EVALUATION_DIDNT_PASS,
       payload: {
         inputDescriptorsUris: ['https://www.w3.org/TR/vc-data-model/#types1'],
-        verifiableCredentialUris: [
-          'https://www.w3.org/2018/credentials/v1',
-          'https://www.w3.org/TR/vc-data-model/#types',
-        ],
+        vcContextUri: ['https://www.w3.org/2018/credentials/v1'],
+        vcCredentialSchema: [{ id: 'https://www.w3.org/TR/vc-data-model/#types' }],
       },
     };
   }
@@ -36,10 +34,8 @@ export class EvaluationClientWrapperData {
       payload: {
         evaluator: 'UriEvaluation',
         inputDescriptorsUris: ['https://www.w3.org/TR/vc-data-model/#types1'],
-        verifiableCredentialUris: [
-          'https://www.w3.org/2018/credentials/v1',
-          'https://www.w3.org/TR/vc-data-model/#types',
-        ],
+        vcContextUri: ['https://www.w3.org/2018/credentials/v1'],
+        vcCredentialSchema: [{ id: 'https://www.w3.org/TR/vc-data-model/#types' }],
       },
     };
   }
@@ -53,10 +49,8 @@ export class EvaluationClientWrapperData {
       message: PEMessages.URI_EVALUATION_DIDNT_PASS,
       payload: {
         inputDescriptorsUris: ['https://www.w3.org/2018/credentials/v1'],
-        verifiableCredentialUris: [
-          'https://www.w3.org/TR/vc-data-model/#types1',
-          'https://www.w3.org/TR/vc-data-model/#types',
-        ],
+        vcContextUri: ['https://www.w3.org/TR/vc-data-model/#types1'],
+        vcCredentialSchema: [{ id: 'https://www.w3.org/TR/vc-data-model/#types' }],
       },
     };
   }
@@ -71,10 +65,8 @@ export class EvaluationClientWrapperData {
       payload: {
         evaluator: 'UriEvaluation',
         inputDescriptorsUris: ['https://www.w3.org/2018/credentials/v1'],
-        verifiableCredentialUris: [
-          'https://www.w3.org/TR/vc-data-model/#types1',
-          'https://www.w3.org/TR/vc-data-model/#types',
-        ],
+        vcContextUri: ['https://www.w3.org/TR/vc-data-model/#types1'],
+        vcCredentialSchema: [{ id: 'https://www.w3.org/TR/vc-data-model/#types' }],
       },
     };
   }

--- a/test/evaluation/EvaluationClientWrapperData.ts
+++ b/test/evaluation/EvaluationClientWrapperData.ts
@@ -18,7 +18,7 @@ export class EvaluationClientWrapperData {
       message: PEMessages.URI_EVALUATION_DIDNT_PASS,
       payload: {
         inputDescriptorsUris: ['https://www.w3.org/TR/vc-data-model/#types1'],
-        vcContextUri: ['https://www.w3.org/2018/credentials/v1'],
+        vcContext: ['https://www.w3.org/2018/credentials/v1'],
         vcCredentialSchema: [{ id: 'https://www.w3.org/TR/vc-data-model/#types' }],
       },
     };
@@ -34,7 +34,7 @@ export class EvaluationClientWrapperData {
       payload: {
         evaluator: 'UriEvaluation',
         inputDescriptorsUris: ['https://www.w3.org/TR/vc-data-model/#types1'],
-        vcContextUri: ['https://www.w3.org/2018/credentials/v1'],
+        vcContext: ['https://www.w3.org/2018/credentials/v1'],
         vcCredentialSchema: [{ id: 'https://www.w3.org/TR/vc-data-model/#types' }],
       },
     };
@@ -49,7 +49,7 @@ export class EvaluationClientWrapperData {
       message: PEMessages.URI_EVALUATION_DIDNT_PASS,
       payload: {
         inputDescriptorsUris: ['https://www.w3.org/2018/credentials/v1'],
-        vcContextUri: ['https://www.w3.org/TR/vc-data-model/#types1'],
+        vcContext: ['https://www.w3.org/TR/vc-data-model/#types1'],
         vcCredentialSchema: [{ id: 'https://www.w3.org/TR/vc-data-model/#types' }],
       },
     };
@@ -65,7 +65,7 @@ export class EvaluationClientWrapperData {
       payload: {
         evaluator: 'UriEvaluation',
         inputDescriptorsUris: ['https://www.w3.org/2018/credentials/v1'],
-        vcContextUri: ['https://www.w3.org/TR/vc-data-model/#types1'],
+        vcContext: ['https://www.w3.org/TR/vc-data-model/#types1'],
         vcCredentialSchema: [{ id: 'https://www.w3.org/TR/vc-data-model/#types' }],
       },
     };

--- a/test/evaluation/EvaluationClientWrapperData.ts
+++ b/test/evaluation/EvaluationClientWrapperData.ts
@@ -18,7 +18,10 @@ export class EvaluationClientWrapperData {
       message: PEMessages.URI_EVALUATION_DIDNT_PASS,
       payload: {
         inputDescriptorsUris: ['https://www.w3.org/TR/vc-data-model/#types1'],
-        presentationDefinitionUris: ['https://www.w3.org/2018/credentials/v1'],
+        verifiableCredentialUris: [
+          'https://www.w3.org/2018/credentials/v1',
+          'https://www.w3.org/TR/vc-data-model/#types',
+        ],
       },
     };
   }
@@ -33,7 +36,10 @@ export class EvaluationClientWrapperData {
       payload: {
         evaluator: 'UriEvaluation',
         inputDescriptorsUris: ['https://www.w3.org/TR/vc-data-model/#types1'],
-        presentationDefinitionUris: ['https://www.w3.org/2018/credentials/v1'],
+        verifiableCredentialUris: [
+          'https://www.w3.org/2018/credentials/v1',
+          'https://www.w3.org/TR/vc-data-model/#types',
+        ],
       },
     };
   }
@@ -47,7 +53,10 @@ export class EvaluationClientWrapperData {
       message: PEMessages.URI_EVALUATION_DIDNT_PASS,
       payload: {
         inputDescriptorsUris: ['https://www.w3.org/2018/credentials/v1'],
-        presentationDefinitionUris: ['https://www.w3.org/TR/vc-data-model/#types1'],
+        verifiableCredentialUris: [
+          'https://www.w3.org/TR/vc-data-model/#types1',
+          'https://www.w3.org/TR/vc-data-model/#types',
+        ],
       },
     };
   }
@@ -62,7 +71,10 @@ export class EvaluationClientWrapperData {
       payload: {
         evaluator: 'UriEvaluation',
         inputDescriptorsUris: ['https://www.w3.org/2018/credentials/v1'],
-        presentationDefinitionUris: ['https://www.w3.org/TR/vc-data-model/#types1'],
+        verifiableCredentialUris: [
+          'https://www.w3.org/TR/vc-data-model/#types1',
+          'https://www.w3.org/TR/vc-data-model/#types',
+        ],
       },
     };
   }

--- a/test/evaluation/evaluationClient.spec.ts
+++ b/test/evaluation/evaluationClient.spec.ts
@@ -35,7 +35,10 @@ describe('evaluate', () => {
       message: PEMessages.URI_EVALUATION_DIDNT_PASS,
       payload: {
         inputDescriptorsUris: ['https://www.w3.org/TR/vc-data-model/#types1'],
-        presentationDefinitionUris: ['https://www.w3.org/2018/credentials/v1'],
+        verifiableCredentialUris: [
+          'https://www.w3.org/2018/credentials/v1',
+          'https://www.w3.org/TR/vc-data-model/#types',
+        ],
       },
     });
   });
@@ -73,7 +76,10 @@ describe('evaluate', () => {
       message: PEMessages.URI_EVALUATION_DIDNT_PASS,
       payload: {
         inputDescriptorsUris: ['https://www.w3.org/2018/credentials/v1'],
-        presentationDefinitionUris: ['https://www.w3.org/TR/vc-data-model/#types1'],
+        verifiableCredentialUris: [
+          'https://www.w3.org/TR/vc-data-model/#types1',
+          'https://www.w3.org/TR/vc-data-model/#types',
+        ],
       },
     });
   });

--- a/test/evaluation/evaluationClient.spec.ts
+++ b/test/evaluation/evaluationClient.spec.ts
@@ -35,10 +35,8 @@ describe('evaluate', () => {
       message: PEMessages.URI_EVALUATION_DIDNT_PASS,
       payload: {
         inputDescriptorsUris: ['https://www.w3.org/TR/vc-data-model/#types1'],
-        verifiableCredentialUris: [
-          'https://www.w3.org/2018/credentials/v1',
-          'https://www.w3.org/TR/vc-data-model/#types',
-        ],
+        vcContextUri: ['https://www.w3.org/2018/credentials/v1'],
+        vcCredentialSchema: [{ id: 'https://www.w3.org/TR/vc-data-model/#types' }],
       },
     });
   });
@@ -76,9 +74,11 @@ describe('evaluate', () => {
       message: PEMessages.URI_EVALUATION_DIDNT_PASS,
       payload: {
         inputDescriptorsUris: ['https://www.w3.org/2018/credentials/v1'],
-        verifiableCredentialUris: [
-          'https://www.w3.org/TR/vc-data-model/#types1',
-          'https://www.w3.org/TR/vc-data-model/#types',
+        vcContextUri: ['https://www.w3.org/TR/vc-data-model/#types1'],
+        vcCredentialSchema: [
+          {
+            id: 'https://www.w3.org/TR/vc-data-model/#types',
+          },
         ],
       },
     });

--- a/test/evaluation/evaluationClient.spec.ts
+++ b/test/evaluation/evaluationClient.spec.ts
@@ -35,7 +35,7 @@ describe('evaluate', () => {
       message: PEMessages.URI_EVALUATION_DIDNT_PASS,
       payload: {
         inputDescriptorsUris: ['https://www.w3.org/TR/vc-data-model/#types1'],
-        vcContextUri: ['https://www.w3.org/2018/credentials/v1'],
+        vcContext: ['https://www.w3.org/2018/credentials/v1'],
         vcCredentialSchema: [{ id: 'https://www.w3.org/TR/vc-data-model/#types' }],
       },
     });
@@ -74,7 +74,7 @@ describe('evaluate', () => {
       message: PEMessages.URI_EVALUATION_DIDNT_PASS,
       payload: {
         inputDescriptorsUris: ['https://www.w3.org/2018/credentials/v1'],
-        vcContextUri: ['https://www.w3.org/TR/vc-data-model/#types1'],
+        vcContext: ['https://www.w3.org/TR/vc-data-model/#types1'],
         vcCredentialSchema: [
           {
             id: 'https://www.w3.org/TR/vc-data-model/#types',

--- a/test/evaluation/uriEvaluationHandler.spec.ts
+++ b/test/evaluation/uriEvaluationHandler.spec.ts
@@ -52,7 +52,7 @@ describe('evaluate', () => {
         PEMessages.URI_EVALUATION_DIDNT_PASS,
         {
           inputDescriptorsUris: ['https://www.w3.org/2018/credentials/v1'],
-          vcContextUri: ['https://www.test.org/mock'],
+          vcContext: ['https://www.test.org/mock'],
           vcCredentialSchema: [
             {
               id: 'https://www.w3.org/TR/vc-data-model/#types',

--- a/test/evaluation/uriEvaluationHandler.spec.ts
+++ b/test/evaluation/uriEvaluationHandler.spec.ts
@@ -52,7 +52,7 @@ describe('evaluate', () => {
         PEMessages.URI_EVALUATION_DIDNT_PASS,
         {
           inputDescriptorsUris: ['https://www.w3.org/2018/credentials/v1'],
-          presentationDefinitionUris: ['https://www.test.org/mock'],
+          verifiableCredentialUris: ['https://www.test.org/mock', 'https://www.w3.org/TR/vc-data-model/#types'],
         }
       )
     );

--- a/test/evaluation/uriEvaluationHandler.spec.ts
+++ b/test/evaluation/uriEvaluationHandler.spec.ts
@@ -52,7 +52,12 @@ describe('evaluate', () => {
         PEMessages.URI_EVALUATION_DIDNT_PASS,
         {
           inputDescriptorsUris: ['https://www.w3.org/2018/credentials/v1'],
-          verifiableCredentialUris: ['https://www.test.org/mock', 'https://www.w3.org/TR/vc-data-model/#types'],
+          vcContextUri: ['https://www.test.org/mock'],
+          vcCredentialSchema: [
+            {
+              id: 'https://www.w3.org/TR/vc-data-model/#types',
+            },
+          ],
         }
       )
     );


### PR DESCRIPTION
changed uriEvaluation to also check the credentialSchema(s) uri, plus changed the uriEvaluation payload from presentationDefinitionUris to verifiableCredentialUris

- Bug fix / Feature
  - added getCredentialSchema method to both jwt and json-ld credentials
  - altered uriEvaluation to also check credentialSchema id against presentationDefinition schema (this is just for version 1 of presentation definition)
  - altered the message payload to be more precise:

```
from:
payload: {
        evaluator: 'UriEvaluation',
        inputDescriptorsUris: [...],
        presentationDefinitionUris: [...]
      },
to:
payload: {
        evaluator: 'UriEvaluation',
        inputDescriptorsUris: [...],
        verifiableCredentialUris: [...]
      },
```
