### PR TITLE
Bugfix/essifi 166 fix exposing internal vcs

### DIFF
--- a/lib/PEX.ts
+++ b/lib/PEX.ts
@@ -240,7 +240,7 @@ export class PEX {
 
     const holderDIDs: string[] = holder ? [holder] : [];
     const limitDisclosureSignatureSuites = limitedDisclosureSuites();
-    this.evaluateCredentials(
+    const evaluationResult = this.evaluateCredentials(
       presentationDefinition,
       SSITypesBuilder.mapExternalVerifiableCredentialsToInternal(selectedCredentials),
       holderDIDs,
@@ -249,7 +249,7 @@ export class PEX {
 
     const presentation = this.presentationFrom(
       presentationDefinition,
-      SSITypesBuilder.mapExternalVerifiableCredentialsToInternal(selectedCredentials),
+      SSITypesBuilder.mapExternalVerifiableCredentialsToInternal(evaluationResult.verifiableCredential),
       holder
     );
     const evaluationResults = this.evaluatePresentation(

--- a/lib/PEX.ts
+++ b/lib/PEX.ts
@@ -95,7 +95,7 @@ export class PEX {
    */
   public selectFrom(
     presentationDefinition: PresentationDefinitionV1 | PresentationDefinitionV2,
-    verifiableCredentials: InternalVerifiableCredential[],
+    verifiableCredentials: VerifiableCredential[],
     holderDIDs: string[],
     limitDisclosureSignatureSuites: string[]
   ): SelectResults {
@@ -142,7 +142,7 @@ export class PEX {
 
   public static getPresentation(
     presentationSubmission: PresentationSubmission,
-    selectedCredential: InternalVerifiableCredential[],
+    selectedCredential: VerifiableCredential[],
     holderDID?: string
   ): Presentation {
     const holder = holderDID;
@@ -157,7 +157,7 @@ export class PEX {
       ],
       holder,
       presentation_submission: presentationSubmission,
-      verifiableCredential: SSITypesBuilder.mapInternalVerifiableCredentialsToExternal(selectedCredential),
+      verifiableCredential: selectedCredential,
     };
   }
 
@@ -184,22 +184,6 @@ export class PEX {
           target: presentationDefinition,
         });
     return new ValidationEngine().validate(validators);
-  }
-
-  /**
-   * This method validates whether an object is usable as a presentation definition or not.
-   *
-   * @param presentationDefinitionV2 the object to be validated.
-   *
-   * @return the validation results to reveal what is acceptable/unacceptable about the passed object to be considered a valid presentation definition
-   */
-  public validateDefinitionV2(presentationDefinitionV2: PresentationDefinitionV2): Validated {
-    return new ValidationEngine().validate([
-      {
-        bundler: new PresentationDefinitionV2VB('root'),
-        target: presentationDefinitionV2,
-      },
-    ]);
   }
 
   /**

--- a/lib/PEXv1.ts
+++ b/lib/PEXv1.ts
@@ -88,7 +88,7 @@ export class PEXv1 {
    */
   public selectFrom(
     presentationDefinition: PresentationDefinitionV1,
-    verifiableCredentials: InternalVerifiableCredential[],
+    verifiableCredentials: VerifiableCredential[],
     holderDIDs: string[],
     limitDisclosureSignatureSuites: string[]
   ): SelectResults {

--- a/lib/PEXv2.ts
+++ b/lib/PEXv2.ts
@@ -60,7 +60,7 @@ export class PEXv2 {
    */
   public evaluateCredentials(
     presentationDefinition: PresentationDefinitionV2,
-    verifiableCredentials: InternalVerifiableCredential[],
+    verifiableCredentials: VerifiableCredential[],
     holderDIDs: string[],
     limitDisclosureSignatureSuites: string[]
   ): EvaluationResults {
@@ -87,7 +87,7 @@ export class PEXv2 {
    */
   public selectFrom(
     presentationDefinition: PresentationDefinitionV2,
-    verifiableCredentials: InternalVerifiableCredential[],
+    verifiableCredentials: VerifiableCredential[],
     holderDIDs: string[],
     limitDisclosureSignatureSuites: string[]
   ): SelectResults {
@@ -114,14 +114,15 @@ export class PEXv2 {
    */
   public presentationFrom(
     presentationDefinition: PresentationDefinitionV2,
-    selectedCredential: InternalVerifiableCredential[],
+    selectedCredential: VerifiableCredential[],
     holderDID?: string
   ): Presentation {
+    const verifiableCredentialCopy = JSON.parse(JSON.stringify(selectedCredential));
     const presentationSubmission = this._evaluationClientWrapper.submissionFrom(
       SSITypesBuilder.createInternalPresentationDefinitionV2FromModelEntity(presentationDefinition),
-      selectedCredential
+      SSITypesBuilder.mapExternalVerifiableCredentialsToInternal(verifiableCredentialCopy)
     );
-    return PEX.getPresentation(presentationSubmission, selectedCredential, holderDID);
+    return PEX.getPresentation(presentationSubmission, verifiableCredentialCopy, holderDID);
   }
 
   /**

--- a/lib/evaluation/core/selectResults.ts
+++ b/lib/evaluation/core/selectResults.ts
@@ -1,5 +1,5 @@
 import { Checked, Status } from '../../ConstraintUtils';
-import { InternalVerifiableCredential } from '../../types';
+import { VerifiableCredential } from '../../types/SSI.types';
 
 import { SubmissionRequirementMatch } from './submissionRequirementMatch';
 
@@ -18,7 +18,7 @@ export interface SelectResults {
   /**
    * All matched/selectable credentials
    */
-  verifiableCredential?: InternalVerifiableCredential[];
+  verifiableCredential?: VerifiableCredential[];
   /**
    * Following are indexes of the verifiableCredentials passed to the selectFrom method that have been selected.
    */

--- a/lib/evaluation/evaluationClientWrapper.ts
+++ b/lib/evaluation/evaluationClientWrapper.ts
@@ -3,7 +3,8 @@ import jp from 'jsonpath';
 
 import { Checked, Status } from '../ConstraintUtils';
 import { InternalVerifiableCredential } from '../types';
-import { InternalPresentationDefinition } from '../types/SSI.types';
+import { InternalPresentationDefinition, VerifiableCredential } from '../types/SSI.types';
+import { SSITypesBuilder } from '../types/SSITypesBuilder';
 import { JsonPathUtils } from '../utils';
 
 import { SelectResults, SubmissionRequirementMatch } from './core';
@@ -53,7 +54,7 @@ export class EvaluationClientWrapper {
         errors: errors,
         matches: [...matchSubmissionRequirements],
         areRequiredCredentialsPresent: Status.INFO,
-        verifiableCredential: [...credentials],
+        verifiableCredential: SSITypesBuilder.mapInternalVerifiableCredentialsToExternal(credentials),
         warnings,
       };
     } else {
@@ -69,7 +70,7 @@ export class EvaluationClientWrapper {
         errors: errors,
         matches: [...matchSubmissionRequirements],
         areRequiredCredentialsPresent: Status.INFO,
-        verifiableCredential: [...credentials],
+        verifiableCredential: SSITypesBuilder.mapInternalVerifiableCredentialsToExternal(credentials),
         warnings,
       };
     }
@@ -197,6 +198,7 @@ export class EvaluationClientWrapper {
       result.value = JSON.parse(JSON.stringify(this._client.presentationSubmission));
     }
     this.updatePresentationSubmissionPathToAlias('verifiableCredential', result.value);
+    result.verifiableCredential = this._client.verifiableCredential;
     return result;
   }
 
@@ -401,7 +403,7 @@ export class EvaluationClientWrapper {
     verifiableCredentials: InternalVerifiableCredential[]
   ) {
     if (selectResults) {
-      selectResults.verifiableCredential?.forEach((selectableCredential: InternalVerifiableCredential) => {
+      selectResults.verifiableCredential?.forEach((selectableCredential: VerifiableCredential) => {
         const foundIndex: number = verifiableCredentials.findIndex(
           (verifiableCredential) => selectableCredential.id === verifiableCredential.id
         );

--- a/lib/evaluation/evaluationResults.ts
+++ b/lib/evaluation/evaluationResults.ts
@@ -1,11 +1,11 @@
 import { PresentationSubmission } from '@sphereon/pex-models';
 
 import { Checked } from '../ConstraintUtils';
-import { InternalVerifiableCredential } from '../types';
+import { VerifiableCredential } from '../types/SSI.types';
 
 export interface EvaluationResults {
   value?: PresentationSubmission;
   warnings?: Checked[];
   errors?: Checked[];
-  verifiableCredential: InternalVerifiableCredential[];
+  verifiableCredential: VerifiableCredential[];
 }

--- a/lib/types/SSI.types.ts
+++ b/lib/types/SSI.types.ts
@@ -283,9 +283,35 @@ export interface Credential {
   [x: string]: unknown;
 }
 
-export interface VerifiableCredential extends Credential {
+export interface JwtVerifiableCredential {
+  aud?: string;
+  exp?: string;
+  iss: string;
+  jti?: string;
+  nbf?: string;
+  sub?: string;
+  vc: InternalCredentialBase;
+  [x: string]: unknown;
   proof: Proof | Proof[];
 }
+
+export interface JsonLdVerifiableCredential {
+  '@context': string[] | string;
+  credentialStatus?: CredentialStatus;
+  credentialSubject: CredentialSubject;
+  credentialSchema?: CredentialSchema | CredentialSchema[];
+  description?: string;
+  expirationDate?: string;
+  id: string;
+  issuanceDate: string;
+  issuer: unknown;
+  name?: string;
+  type: string[];
+  [x: string]: unknown;
+  proof: Proof | Proof[];
+}
+
+export type VerifiableCredential = JwtVerifiableCredential | JsonLdVerifiableCredential;
 
 export interface InternalPresentationDefinition {
   format?: Format;

--- a/lib/types/SSI.types.ts
+++ b/lib/types/SSI.types.ts
@@ -251,38 +251,6 @@ export class InternalVerifiableCredentialJwt extends InternalCredentialJWT {
 
 export type InternalVerifiableCredential = InternalVerifiableCredentialJsonLD | InternalVerifiableCredentialJwt;
 
-export interface Credential {
-  /**
-   * Below are the jwt related credentials
-   */
-  aud?: string;
-  exp?: string;
-  iss?: string;
-  jti?: string;
-  nbf?: string;
-  sub?: string;
-  vc?: InternalCredentialBase;
-  // JWT related fields end
-
-  /**
-   * Below are the json-ld related credentials
-   */
-  '@context'?: string[] | string;
-  credentialStatus?: CredentialStatus;
-  credentialSubject?: CredentialSubject;
-  description?: string;
-  expirationDate?: string;
-  id?: string;
-  issuanceDate?: string;
-  issuer?: unknown;
-  name?: string;
-  type?: string[];
-
-  // JSON-LD related fields end
-
-  [x: string]: unknown;
-}
-
 export interface JwtVerifiableCredential {
   aud?: string;
   exp?: string;

--- a/lib/types/SSI.types.ts
+++ b/lib/types/SSI.types.ts
@@ -251,7 +251,7 @@ export class InternalVerifiableCredentialJwt extends InternalCredentialJWT {
 
 export type InternalVerifiableCredential = InternalVerifiableCredentialJsonLD | InternalVerifiableCredentialJwt;
 
-export interface JwtVerifiableCredential {
+export interface JwtCredential {
   aud?: string;
   exp?: string;
   iss: string;
@@ -260,10 +260,9 @@ export interface JwtVerifiableCredential {
   sub?: string;
   vc: InternalCredentialBase;
   [x: string]: unknown;
-  proof: Proof | Proof[];
 }
 
-export interface JsonLdVerifiableCredential {
+export interface JsonLdCredential {
   '@context': string[] | string;
   credentialStatus?: CredentialStatus;
   credentialSubject: CredentialSubject;
@@ -276,6 +275,15 @@ export interface JsonLdVerifiableCredential {
   name?: string;
   type: string[];
   [x: string]: unknown;
+}
+
+export type Credential = JwtCredential | JsonLdCredential;
+
+export interface JwtVerifiableCredential extends JwtCredential {
+  proof: Proof | Proof[];
+}
+
+export interface JsonLdVerifiableCredential extends JsonLdCredential {
   proof: Proof | Proof[];
 }
 

--- a/lib/types/SSITypesBuilder.ts
+++ b/lib/types/SSITypesBuilder.ts
@@ -53,4 +53,20 @@ export class SSITypesBuilder {
     }
     throw 'VerifiableCredential structure is incorrect.';
   }
+
+  static mapInternalVerifiableCredentialsToExternal(
+    internalCredentials: InternalVerifiableCredential[]
+  ): VerifiableCredential[] {
+    const externalVCs: VerifiableCredential[] = [];
+    for (const internalCredential of internalCredentials) {
+      externalVCs.push(this.mapInternalVerifiableCredentialToExternal(internalCredential));
+    }
+    return externalVCs;
+  }
+
+  private static mapInternalVerifiableCredentialToExternal(
+    internalCredential: InternalVerifiableCredential
+  ): VerifiableCredential {
+    return internalCredential as VerifiableCredential;
+  }
 }

--- a/lib/types/SSITypesBuilder.ts
+++ b/lib/types/SSITypesBuilder.ts
@@ -43,38 +43,6 @@ export class SSITypesBuilder {
     return internalVCs;
   }
 
-  static mapInternalVerifiableCredentialsToExternal(
-    internalCredentials: InternalVerifiableCredential[]
-  ): VerifiableCredential[] {
-    const externalVCs: VerifiableCredential[] = [];
-    for (const internalCredential of internalCredentials) {
-      externalVCs.push(this.mapInternalVerifiableCredentialToExternal(internalCredential));
-    }
-    return externalVCs;
-  }
-
-  private static mapInternalVerifiableCredentialToExternal(
-    internalCredential: InternalVerifiableCredential
-  ): VerifiableCredential {
-    if (internalCredential.getType() === 'json-ld') {
-      return {
-        ...internalCredential.getBaseCredential(),
-        proof: internalCredential.proof,
-      };
-    } else {
-      return {
-        aud: internalCredential.getAudience(),
-        exp: internalCredential.getExpirationDate(),
-        iss: internalCredential.getIssuer() as string,
-        jti: internalCredential.getJti(),
-        nbf: internalCredential.getIssuanceDate(),
-        sub: internalCredential.getId(),
-        vc: internalCredential.getBaseCredential(),
-        proof: internalCredential.proof,
-      };
-    }
-  }
-
   private static mapExternalVerifiableCredentialToInternal(externalCredential: VerifiableCredential) {
     if (externalCredential.vc && externalCredential.iss) {
       const vc: InternalVerifiableCredential = new InternalVerifiableCredentialJwt();

--- a/test/PEX.spec.ts
+++ b/test/PEX.spec.ts
@@ -164,7 +164,7 @@ describe('evaluate', () => {
   it('Evaluate presentationDefinition v2', () => {
     const pd: PresentationDefinitionV2 = getPresentationDefinitionV2();
     const pejs: PEX = new PEX();
-    const result: Validated = pejs.validateDefinitionV2(pd);
+    const result: Validated = pejs.validateDefinition(pd);
     expect(result).toEqual([{ message: 'ok', status: 'info', tag: 'root' }]);
   });
 
@@ -172,7 +172,7 @@ describe('evaluate', () => {
     const pd: PresentationDefinitionV2 = getPresentationDefinitionV2();
     pd.frame = { '@id': 'this is not valid' };
     const pejs: PEX = new PEX();
-    const result: Validated = pejs.validateDefinitionV2(pd);
+    const result: Validated = pejs.validateDefinition(pd);
     expect(result).toEqual([
       { message: 'frame value is not valid', status: 'error', tag: 'presentation_definition.frame' },
     ]);


### PR DESCRIPTION
PEX (and PEXv1/PEXv2) are exposing InternalVerifiableCredential in several places to the outside world

- Refactored these usages to outside world VerifiableCredential
- Separated Jwt and Json-LD verifiable credential interface