### PR TITLE
docs: Update documentation and flow diagram to make a clear distincti…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Release Notes
+
 ---
 **Breaking change: class and package renamed as of v0.6.0!**
 

--- a/docs/simple-scenario.puml
+++ b/docs/simple-scenario.puml
@@ -1,41 +1,52 @@
 @startuml
 
-header PEX
+header Presentation Exchange
 
 title
-PEX
-Data Flow Diagram - version 0.1.0
+Presentation Exchange
+General PEX Flow between a holder and verifier
 end title
 
 
 autonumber
 
-participant "PEX-Verifier" as PE2 order 0 #ORANGE
+participant "PEX-Lib Verifier" as PEXV order 0 #ORANGE
 participant "Verifier" as V order 1 #ORANGE
 participant "Alice" as A order 2 #PINK
 participant "Wallet" as W order 3 #YELLOW
-participant "PEX" as PE order 4 #YELLOW
+participant "PEX-Lib Wallet" as PE order 4 #YELLOW
 
 V -> W: PresentationDefinition
 W -> A: Notification
 A -> W: Accepts PresentationDefinition
 W -> PE: evaluate(presentationDefinition, allAvailableCredentials[])
 PE -> W: evaluation results
-W -> A: from the credentials that you've selected, \na combination of these are acceptable
-A -> W: selects a combination of credentials
+W -> A: from the credentials in your wallet, \na combination is acceptable
+loop
+A -> W: selects a more specific combination of credentials
 W -> PE: selectFrom(2ndSetOfCredentials[])
+note left
+    Could be called in multiple rounds until,
+    areRequiredCredentialsPresent contains Status.INFO
+end note
 PE -> W: selectFrom response
-W -> PE: submissionFrom(selectableCredentials)
-PE -> W: submissionFrom response
+W -> A: Inform success/error selection
+end
 
-W -> PE: createPresentation(selectFromResult)
-PE -> W: get an actual IPresentation object
+A -> W: Create presentation with selection and definition
+
+alt Unsigned Presentation
+W -> PE: createPresentation(presentationDefinition, selectFromResult)
+PE -> W: returns an Unsigned Presentation object
 W -> W: signPresentation(presentation)
+else Verifiable Presentation
+W -> PE: createVerifiablePresentation\n(presentationDefinition, selectFromResult, signCallback)
+PE -> W: returns a Verifiable Presentation object
+end
+W -> V: VerifiablePresentation containing Presentation Submission
 
-W -> V: IVerifiablePresentation
-
-V -> PE2: evaluate(IVerifiableCredential)
-PE2 -> V: evaluation result
+V -> PEXV: evaluate(verifiablePresentation)
+PEXV -> V: evaluation result
 V -> W: Pass/Fail response
 W -> A: Pass/Fail notification
 @enduml

--- a/lib/PEX.ts
+++ b/lib/PEX.ts
@@ -16,7 +16,7 @@ import {
 import { PresentationDefinitionSchema } from './validation/core/presentationDefinitionSchema';
 
 /**
- * This is the main interfacing class to be used from out side the library to use the functionality provided by the library.
+ * This is the main interfacing class to be used by developers using the PEX library.
  */
 export class PEX {
   private _evaluationClientWrapper: EvaluationClientWrapper;
@@ -83,12 +83,12 @@ export class PEX {
   }
 
   /**
-   * The selectFromV1 method is a helper function that helps filter out the verifiable credentials which can not be selected and returns
+   * The selectFrom method is a helper function that helps filter out the verifiable credentials which can not be selected and returns
    * the selectable credentials.
    *
-   * @param presentationDefinition the v1 definition of what is expected in the presentation.
+   * @param presentationDefinition the v1 or v2 definition of what is expected in the presentation.
    * @param verifiableCredentials verifiable credentials are the credentials from wallet provided to the library to find selectable credentials.
-   * @param holderDIDs the decentralized identity of the wallet holder. This is used to identify the credentials issued to the holder of wallet.
+   * @param holderDIDs the decentralized identifier(s) of the wallet holder. This is used to identify the credentials issued to the holder of wallet in certain scenario's.
    * @param limitDisclosureSignatureSuites the credential signature suites that support limit disclosure
    *
    * @return the selectable credentials.
@@ -112,10 +112,10 @@ export class PEX {
   }
 
   /**
-   * This method helps create a submittablePresentation. A submittablePresentation after signing becomes a Presentation. And can be sent to
+   * This method helps create an Unsigned Presentation. An Unsigned Presentation after signing becomes a Presentation. And can be sent to
    * the verifier after signing it.
    *
-   * @param presentationDefinition the v1 definition of what is expected in the presentation.
+   * @param presentationDefinition the v1 or v2 definition of what is expected in the presentation.
    * @param selectedCredential the credentials which were declared selectable by getSelectableCredentials and then chosen by the intelligent-user
    * (e.g. human).
    * @param holderDID optional; the decentralized identity of the wallet holder. This is used to identify the holder of the presentation.
@@ -211,7 +211,7 @@ export class PEX {
    * It is up to you to decide whether you simply update the supplied partial proof and add it to the presentation in the callback,
    * or whether you will use the selected Credentials, Presentation definition, evaluation results and/or presentation submission together with the signature options
    *
-   * @param presentationDefinition the Presentation Definition V1
+   * @param presentationDefinition the Presentation Definition V1 or V2
    * @param selectedCredentials the PE-JS and/or User selected/filtered credentials that will become part of the Verifiable Presentation
    * @param signingCallBack the function which will be provided as a parameter. And this will be the method that will be able to perform actual
    *        signing. One example of signing is available in the project named. pe-selective-disclosure.
@@ -220,7 +220,7 @@ export class PEX {
    * @return the signed and thus Verifiable Presentation.
    */
   public verifiablePresentationFrom(
-    presentationDefinition: PresentationDefinitionV1,
+    presentationDefinition: PresentationDefinitionV1 | PresentationDefinitionV2,
     selectedCredentials: IVerifiableCredential[],
     signingCallBack: (callBackParams: PresentationSignCallBackParams) => IVerifiablePresentation,
     options: PresentationSignOptions


### PR DESCRIPTION
Update documentation and flow diagram to make a clear distinction between holder/wallet and verifier.

Also fixed some left over refactor strings (IPresentation/ICredential) in the docs

Lastly noticed PEX having a method that only accepted V1 def. Added V2
