### PR TITLE
ESSIFI-167: substituted not escaped path with escaped path

### DIFF
--- a/lib/types/SSITypesBuilder.ts
+++ b/lib/types/SSITypesBuilder.ts
@@ -13,7 +13,7 @@ import { IHasProof, IJwtCredential, IPresentationDefinition, IVerifiableCredenti
 
 export class SSITypesBuilder {
   public static createInternalPresentationDefinitionV1FromModelEntity(p: PdV1): InternalPresentationDefinitionV1 {
-    const pd: PdV1 = SSITypesBuilder.createCopyAndChangePropertyName(p) as PdV1;
+    const pd: PdV1 = SSITypesBuilder.createCopyAndModifyPresentationDefinition(p) as PdV1;
     return new InternalPresentationDefinitionV1(
       pd.id,
       pd.input_descriptors,
@@ -25,7 +25,7 @@ export class SSITypesBuilder {
   }
 
   public static createInternalPresentationDefinitionV2FromModelEntity(p: PdV2): InternalPresentationDefinitionV2 {
-    const pd: PdV2 = SSITypesBuilder.createCopyAndChangePropertyName(p);
+    const pd: PdV2 = SSITypesBuilder.createCopyAndModifyPresentationDefinition(p);
     return new InternalPresentationDefinitionV2(
       pd.id,
       pd.input_descriptors,
@@ -36,10 +36,11 @@ export class SSITypesBuilder {
       pd.submission_requirements
     );
   }
-  static createCopyAndChangePropertyName(p: IPresentationDefinition): IPresentationDefinition {
+  static createCopyAndModifyPresentationDefinition(p: IPresentationDefinition): IPresentationDefinition {
     const pd: IPresentationDefinition = JSON.parse(JSON.stringify(p));
     JsonPathUtils.changePropertyNameRecursively(pd, '_const', 'const');
     JsonPathUtils.changePropertyNameRecursively(pd, '_enum', 'enum');
+    JsonPathUtils.changeSpecialPathsRecursively(pd);
     return pd;
   }
 

--- a/lib/utils/jsonPathUtils.ts
+++ b/lib/utils/jsonPathUtils.ts
@@ -122,7 +122,7 @@ export class JsonPathUtils {
     let next = matches.next();
     while (next && !next.done) {
       const atIdx = (next.value[0] as string).indexOf('@');
-      if (atIdx == 1) {
+      if (atIdx <= 1) {
         path = path.replace(next.value[0], "['" + next.value[2] + "']");
       } else if (atIdx > 1) {
         path = path.replace(next.value[0], "..['" + next.value[2] + "']");

--- a/lib/utils/jsonPathUtils.ts
+++ b/lib/utils/jsonPathUtils.ts
@@ -117,36 +117,16 @@ export class JsonPathUtils {
   }
 
   private static modifyPathWithSpecialCharacter(path: string): string {
-    const REGEX_PATH_ESCAPED = /\['@\w+']/g;
-    const REGEX_PATH = /@\w+/g;
-    const resultEscaped = path.matchAll(REGEX_PATH_ESCAPED);
-    const resultNotEscaped = path.matchAll(REGEX_PATH);
+    const REGEX_PATH = /(^((?!\[').)*)(@\w+)/g;
+    const matches = path.matchAll(REGEX_PATH);
     let nextExist = true;
-    const escapedIndices = [];
     while (nextExist) {
-      const next = resultEscaped.next();
+      const next = matches.next();
       if (!next.done) {
-        escapedIndices.push(next.value['index']);
+        path = path.replace(next.value[3], ".['" + next.value[3] + "']");
         nextExist = true;
       } else {
         nextExist = false;
-      }
-    }
-    nextExist = true;
-    const indices: Map<number, string> = new Map<number, string>();
-    while (nextExist) {
-      const next = resultNotEscaped.next();
-      if (!next.done) {
-        indices.set(<number>next.value['index'], next.value[0]);
-        nextExist = true;
-      } else {
-        nextExist = false;
-      }
-    }
-    for (let i = 0; i < indices.size; i++) {
-      const value = indices.entries().next();
-      if (!escapedIndices.find((el) => el == value.value[0] - 2)) {
-        path = path.replace(REGEX_PATH, ".['" + value.value[1] + "']");
       }
     }
     return path;

--- a/lib/utils/jsonPathUtils.ts
+++ b/lib/utils/jsonPathUtils.ts
@@ -117,17 +117,17 @@ export class JsonPathUtils {
   }
 
   private static modifyPathWithSpecialCharacter(path: string): string {
-    const REGEX_PATH = /(^((?!\[').)*)(@\w+)/g;
+    const REGEX_PATH = /(\.{0,2})(?<!\[')(@\w+)(?!\w'])/g;
     const matches = path.matchAll(REGEX_PATH);
-    let nextExist = true;
-    while (nextExist) {
-      const next = matches.next();
-      if (!next.done) {
-        path = path.replace(next.value[3], ".['" + next.value[3] + "']");
-        nextExist = true;
-      } else {
-        nextExist = false;
+    let next = matches.next();
+    while (next && !next.done) {
+      const atIdx = (next.value[0] as string).indexOf('@');
+      if (atIdx == 1) {
+        path = path.replace(next.value[0], "['" + next.value[2] + "']");
+      } else if (atIdx > 1) {
+        path = path.replace(next.value[0], "..['" + next.value[2] + "']");
       }
+      next = matches.next();
     }
     return path;
   }

--- a/lib/utils/jsonPathUtils.ts
+++ b/lib/utils/jsonPathUtils.ts
@@ -122,11 +122,10 @@ export class JsonPathUtils {
     let next = matches.next();
     while (next && !next.done) {
       const atIdx = (next.value[0] as string).indexOf('@');
-      if (atIdx <= 1) {
-        path = path.replace(next.value[0], "['" + next.value[2] + "']");
-      } else if (atIdx > 1) {
-        path = path.replace(next.value[0], "..['" + next.value[2] + "']");
-      }
+      path =
+        atIdx <= 1
+          ? path.replace(next.value[0], "['" + next.value[2] + "']")
+          : path.replace(next.value[0], "..['" + next.value[2] + "']");
       next = matches.next();
     }
     return path;

--- a/test/PEXv2.spec.ts
+++ b/test/PEXv2.spec.ts
@@ -360,4 +360,62 @@ describe('evaluate', () => {
     expect(result).toEqual([{ message: 'ok', status: 'info', tag: 'root' }]);
     expect(pd.input_descriptors![0].constraints!.fields![0].filter!['_enum' as keyof FilterV2]).toEqual(['red']);
   });
+
+  it('should return ok if presentation definition @ in path works properly', () => {
+    const pd: PresentationDefinitionV2 = getPresentationDefinitionV2_3();
+    pd.input_descriptors[0].constraints!.fields = [
+      {
+        path: ['$.@context', '$.vc.@context'],
+        purpose:
+          'We can only verify bank accounts if they are attested by a trusted bank, auditor, or regulatory authority.',
+        filter: {
+          type: 'string',
+          _const: 'https://eu.com/claims/DriversLicense',
+        },
+      },
+    ];
+    const pex: PEXv2 = new PEXv2();
+    const vpSimple = getFile('./test/dif_pe_examples/vp/vp_general.json') as IVerifiablePresentation;
+    const result = pex.evaluateCredentials(pd, vpSimple.verifiableCredential, [], LIMIT_DISCLOSURE_SIGNATURE_SUITES);
+    console.log(JSON.stringify(result, null, 2));
+  });
+
+  it('should return ok if presentation definition @ in path escapes properly', () => {
+    const pd: PresentationDefinitionV2 = getPresentationDefinitionV2_3();
+    pd.input_descriptors[0].constraints!.fields = [
+      {
+        path: ["$..['@context']", "$.vc..['@context']"],
+        purpose:
+          'We can only verify bank accounts if they are attested by a trusted bank, auditor, or regulatory authority.',
+        filter: {
+          type: 'string',
+          _const: 'https://eu.com/claims/DriversLicense',
+        },
+      },
+    ];
+    const pex: PEXv2 = new PEXv2();
+    const vpSimple = getFile('./test/dif_pe_examples/vp/vp_general.json') as IVerifiablePresentation;
+    const result = pex.evaluateCredentials(pd, vpSimple.verifiableCredential, [], LIMIT_DISCLOSURE_SIGNATURE_SUITES);
+    console.log(JSON.stringify(result, null, 2));
+  });
+
+  it('testing', () => {
+    const str3 = 'Chapter 2.7 This text contains references to chapter 4.2.1 & also to chapter 5';
+    const str = "$..['@context']";
+    const regExp3 = /chapter \d+(\.\d)*/gi;
+    const regExp = /@\w+/gi;
+    console.log('MATCH()');
+    console.log(str3.match(regExp3));
+    // return 1 array with 3 found matches (no added data of matches)
+    console.log('MATCHALL()');
+    console.log(...str.matchAll(regExp));
+    // returns 3 arrays with additional details about matches
+    console.log('EASY ACCESS TO ADDITIONAL INFORMATION');
+    const matches = str3.matchAll(regExp3);
+    for (const match of matches) {
+      console.log('MATCH: ' + match[0]);
+      console.log('START: ' + match.index);
+      console.log('  END: ' + (match.index + '' + match[0].length));
+    }
+  });
 });

--- a/test/PEXv2.spec.ts
+++ b/test/PEXv2.spec.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 
 import { FilterV2, PresentationDefinitionV2 } from '@sphereon/pex-models';
 
-import { IVerifiablePresentation, PEXv2, ProofType, Validated, ValidationEngine } from '../lib';
+import { IVerifiablePresentation, PEXv2, ProofType, Status, Validated, ValidationEngine } from '../lib';
 import { PresentationDefinitionV2VB } from '../lib/validation';
 
 import {
@@ -359,5 +359,83 @@ describe('evaluate', () => {
     const result = pex.validateDefinition(pd);
     expect(result).toEqual([{ message: 'ok', status: 'info', tag: 'root' }]);
     expect(pd.input_descriptors![0].constraints!.fields![0].filter!['_enum' as keyof FilterV2]).toEqual(['red']);
+  });
+
+  it('should return ok if presentation definition @ is already escaped properly', () => {
+    const pd: PresentationDefinitionV2 = getPresentationDefinitionV2_1();
+    pd.input_descriptors[0].constraints!.fields = [
+      {
+        path: ["$['@context']", "$.vc['@context']"],
+        purpose: 'We can only verify driver licensed if they have a certain context',
+        filter: {
+          type: 'string',
+          _const: 'https://eu.com/claims/DriversLicense',
+        },
+      },
+    ];
+    delete pd.input_descriptors[0].constraints!.limit_disclosure;
+
+    const vpSimple = getFile('./test/dif_pe_examples/vp/vp_general.json') as IVerifiablePresentation;
+    const pex: PEXv2 = new PEXv2();
+    const result = pex.selectFrom(
+      pd,
+      [vpSimple.verifiableCredential[0]],
+      ['FAsYneKJhWBP2n5E21ZzdY'],
+      LIMIT_DISCLOSURE_SIGNATURE_SUITES
+    );
+    expect(result.areRequiredCredentialsPresent).toBe(Status.INFO);
+    expect(result.errors?.length).toEqual(0);
+  });
+
+  it('should return ok if presentation definition @ in path escapes properly', () => {
+    const pd: PresentationDefinitionV2 = getPresentationDefinitionV2_1();
+    pd.input_descriptors[0].constraints!.fields = [
+      {
+        path: ['$.@context', '$.vc.@context'],
+        purpose: 'We can only verify driver licensed if they have a certain context',
+        filter: {
+          type: 'string',
+          _const: 'https://eu.com/claims/DriversLicense',
+        },
+      },
+    ];
+    delete pd.input_descriptors[0].constraints!.limit_disclosure;
+
+    const vpSimple = getFile('./test/dif_pe_examples/vp/vp_general.json') as IVerifiablePresentation;
+    const pex: PEXv2 = new PEXv2();
+    const result = pex.selectFrom(
+      pd,
+      [vpSimple.verifiableCredential[0]],
+      ['FAsYneKJhWBP2n5E21ZzdY'],
+      LIMIT_DISCLOSURE_SIGNATURE_SUITES
+    );
+    expect(result.areRequiredCredentialsPresent).toBe(Status.INFO);
+    expect(result.errors?.length).toEqual(0);
+  });
+
+  it('should return ok if presentation definition @ in path escapes properly', () => {
+    const pd: PresentationDefinitionV2 = getPresentationDefinitionV2_1();
+    pd.input_descriptors[0].constraints!.fields = [
+      {
+        path: ['$..@context', '$.vc..@context'],
+        purpose: 'We can only verify driver licensed if they have a certain context',
+        filter: {
+          type: 'string',
+          _const: 'https://eu.com/claims/DriversLicense',
+        },
+      },
+    ];
+    delete pd.input_descriptors[0].constraints!.limit_disclosure;
+
+    const vpSimple = getFile('./test/dif_pe_examples/vp/vp_general.json') as IVerifiablePresentation;
+    const pex: PEXv2 = new PEXv2();
+    const result = pex.selectFrom(
+      pd,
+      [vpSimple.verifiableCredential[0]],
+      ['FAsYneKJhWBP2n5E21ZzdY'],
+      LIMIT_DISCLOSURE_SIGNATURE_SUITES
+    );
+    expect(result.areRequiredCredentialsPresent).toBe(Status.INFO);
+    expect(result.errors?.length).toEqual(0);
   });
 });

--- a/test/PEXv2.spec.ts
+++ b/test/PEXv2.spec.ts
@@ -3,6 +3,7 @@ import fs from 'fs';
 import { FilterV2, PresentationDefinitionV2 } from '@sphereon/pex-models';
 
 import { IVerifiablePresentation, PEXv2, ProofType, Validated, ValidationEngine } from '../lib';
+import { SSITypesBuilder } from '../lib/types/SSITypesBuilder';
 import { PresentationDefinitionV2VB } from '../lib/validation';
 
 import {
@@ -399,23 +400,22 @@ describe('evaluate', () => {
     console.log(JSON.stringify(result, null, 2));
   });
 
-  it('testing', () => {
-    const str3 = 'Chapter 2.7 This text contains references to chapter 4.2.1 & also to chapter 5';
-    const str = "$..['@context']";
-    const regExp3 = /chapter \d+(\.\d)*/gi;
-    const regExp = /@\w+/gi;
-    console.log('MATCH()');
-    console.log(str3.match(regExp3));
-    // return 1 array with 3 found matches (no added data of matches)
-    console.log('MATCHALL()');
-    console.log(...str.matchAll(regExp));
-    // returns 3 arrays with additional details about matches
-    console.log('EASY ACCESS TO ADDITIONAL INFORMATION');
-    const matches = str3.matchAll(regExp3);
-    for (const match of matches) {
-      console.log('MATCH: ' + match[0]);
-      console.log('START: ' + match.index);
-      console.log('  END: ' + (match.index + '' + match[0].length));
-    }
+  it("other valid paths in json-ld shouldn't be affected by regex subs", () => {
+    const pd: PresentationDefinitionV2 = getPresentationDefinitionV2_3();
+    pd.input_descriptors[0].constraints!.fields = [
+      {
+        path: ['$..book[(@.length-1)]', '$..book[?(@.price<30 && @.category=="fiction")]', '$..book[?(@.price==8.95)]'],
+        purpose:
+          'We can only verify bank accounts if they are attested by a trusted bank, auditor, or regulatory authority.',
+        filter: {
+          type: 'string',
+          _const: 'https://eu.com/claims/DriversLicense',
+        },
+      },
+    ];
+    const result = SSITypesBuilder.createInternalPresentationDefinitionV2FromModelEntity(pd);
+    expect(result.input_descriptors[0].constraints!.fields![0].path).toEqual(
+      pd.input_descriptors[0].constraints!.fields[0].path
+    );
   });
 });

--- a/test/PEXv2.spec.ts
+++ b/test/PEXv2.spec.ts
@@ -3,7 +3,6 @@ import fs from 'fs';
 import { FilterV2, PresentationDefinitionV2 } from '@sphereon/pex-models';
 
 import { IVerifiablePresentation, PEXv2, ProofType, Validated, ValidationEngine } from '../lib';
-import { SSITypesBuilder } from '../lib/types/SSITypesBuilder';
 import { PresentationDefinitionV2VB } from '../lib/validation';
 
 import {
@@ -360,62 +359,5 @@ describe('evaluate', () => {
     const result = pex.validateDefinition(pd);
     expect(result).toEqual([{ message: 'ok', status: 'info', tag: 'root' }]);
     expect(pd.input_descriptors![0].constraints!.fields![0].filter!['_enum' as keyof FilterV2]).toEqual(['red']);
-  });
-
-  it('should return ok if presentation definition @ in path works properly', () => {
-    const pd: PresentationDefinitionV2 = getPresentationDefinitionV2_3();
-    pd.input_descriptors[0].constraints!.fields = [
-      {
-        path: ['$.@context', '$.vc.@context'],
-        purpose:
-          'We can only verify bank accounts if they are attested by a trusted bank, auditor, or regulatory authority.',
-        filter: {
-          type: 'string',
-          _const: 'https://eu.com/claims/DriversLicense',
-        },
-      },
-    ];
-    const pex: PEXv2 = new PEXv2();
-    const vpSimple = getFile('./test/dif_pe_examples/vp/vp_general.json') as IVerifiablePresentation;
-    const result = pex.evaluateCredentials(pd, vpSimple.verifiableCredential, [], LIMIT_DISCLOSURE_SIGNATURE_SUITES);
-    console.log(JSON.stringify(result, null, 2));
-  });
-
-  it('should return ok if presentation definition @ in path escapes properly', () => {
-    const pd: PresentationDefinitionV2 = getPresentationDefinitionV2_3();
-    pd.input_descriptors[0].constraints!.fields = [
-      {
-        path: ["$..['@context']", "$.vc..['@context']"],
-        purpose:
-          'We can only verify bank accounts if they are attested by a trusted bank, auditor, or regulatory authority.',
-        filter: {
-          type: 'string',
-          _const: 'https://eu.com/claims/DriversLicense',
-        },
-      },
-    ];
-    const pex: PEXv2 = new PEXv2();
-    const vpSimple = getFile('./test/dif_pe_examples/vp/vp_general.json') as IVerifiablePresentation;
-    const result = pex.evaluateCredentials(pd, vpSimple.verifiableCredential, [], LIMIT_DISCLOSURE_SIGNATURE_SUITES);
-    console.log(JSON.stringify(result, null, 2));
-  });
-
-  it("other valid paths in json-ld shouldn't be affected by regex subs", () => {
-    const pd: PresentationDefinitionV2 = getPresentationDefinitionV2_3();
-    pd.input_descriptors[0].constraints!.fields = [
-      {
-        path: ['$..book[(@.length-1)]', '$..book[?(@.price<30 && @.category=="fiction")]', '$..book[?(@.price==8.95)]'],
-        purpose:
-          'We can only verify bank accounts if they are attested by a trusted bank, auditor, or regulatory authority.',
-        filter: {
-          type: 'string',
-          _const: 'https://eu.com/claims/DriversLicense',
-        },
-      },
-    ];
-    const result = SSITypesBuilder.createInternalPresentationDefinitionV2FromModelEntity(pd);
-    expect(result.input_descriptors[0].constraints!.fields![0].path).toEqual(
-      pd.input_descriptors[0].constraints!.fields[0].path
-    );
   });
 });

--- a/test/utils/jsonPathUtils.spec.ts
+++ b/test/utils/jsonPathUtils.spec.ts
@@ -80,7 +80,7 @@ describe('should test jsonPathUtils function', () => {
     expect(result.input_descriptors[0].constraints!.fields![0].path).toEqual(["$..['@context']", "$.vc..['@context']"]);
   });
 
-  it('should return ok if presentation definition @ in path works properly', () => {
+  it('should return ok if presentation definition @ in path works properly - 1', () => {
     const pd: PresentationDefinitionV1 = getPresentationDefinitionV1();
     pd.input_descriptors[0].constraints!.fields = [
       {
@@ -94,6 +94,22 @@ describe('should test jsonPathUtils function', () => {
     ];
     const result = SSITypesBuilder.createInternalPresentationDefinitionV1FromModelEntity(pd);
     expect(result.input_descriptors[0].constraints!.fields![0].path).toEqual(["$['@context']", "$.vc['@context']"]);
+  });
+
+  it('should return ok if presentation definition @ in path works properly - 2', () => {
+    const pd: PresentationDefinitionV1 = getPresentationDefinitionV1();
+    pd.input_descriptors[0].constraints!.fields = [
+      {
+        path: ['$@context'],
+        purpose: 'We can only verify driver licensed if they have a certain context.',
+        filter: {
+          type: 'string',
+          _const: 'https://eu.com/claims/DriversLicense',
+        },
+      },
+    ];
+    const result = SSITypesBuilder.createInternalPresentationDefinitionV1FromModelEntity(pd);
+    expect(result.input_descriptors[0].constraints!.fields![0].path).toEqual(["$['@context']"]);
   });
 
   it("other valid paths in json-ld shouldn't be affected by regex subs", () => {

--- a/test/utils/jsonPathUtils.spec.ts
+++ b/test/utils/jsonPathUtils.spec.ts
@@ -60,7 +60,7 @@ describe('should test jsonPathUtils function', () => {
     ];
     const result = SSITypesBuilder.createInternalPresentationDefinitionV2FromModelEntity(pd);
     expect(result.input_descriptors[0].constraints!.fields![0].path).toEqual([
-      "$..['@book'].accessModeSufficient[(@.length-1)]",
+      "$['@book'].accessModeSufficient[(@.length-1)]",
     ]);
   });
 
@@ -93,7 +93,7 @@ describe('should test jsonPathUtils function', () => {
       },
     ];
     const result = SSITypesBuilder.createInternalPresentationDefinitionV1FromModelEntity(pd);
-    expect(result.input_descriptors[0].constraints!.fields![0].path).toEqual(["$..['@context']", "$.vc..['@context']"]);
+    expect(result.input_descriptors[0].constraints!.fields![0].path).toEqual(["$['@context']", "$.vc['@context']"]);
   });
 
   it("other valid paths in json-ld shouldn't be affected by regex subs", () => {


### PR DESCRIPTION
Escaping @-related properties with correct pre and post-fixes.
related to this issue:
https://github.com/decentralized-identity/presentation-exchange/issues/278