### PR TITLE
fix: make vp from async return value promise

### DIFF
--- a/lib/PEX.ts
+++ b/lib/PEX.ts
@@ -263,7 +263,9 @@ export class PEX {
   public async verifiablePresentationFromAsync(
     presentationDefinition: IPresentationDefinition,
     selectedCredentials: (IVerifiableCredential | JwtWrappedVerifiableCredential | string)[],
-    signingCallBack: (callBackParams: PresentationSignCallBackParams) => Promise<IVerifiablePresentation>,
+    signingCallBack: (
+      callBackParams: PresentationSignCallBackParams
+    ) => Promise<IVerifiablePresentation> | IVerifiablePresentation,
     options: PresentationSignOptions
   ): Promise<IVerifiablePresentation> {
     const { holder, signatureOptions, proofOptions } = options;

--- a/lib/PEXv1.ts
+++ b/lib/PEXv1.ts
@@ -217,7 +217,7 @@ export class PEXv1 {
   public async verifiablePresentationFromAsync(
     presentationDefinition: PresentationDefinitionV1,
     selectedCredentials: (IVerifiableCredential | JwtWrappedVerifiableCredential | string)[],
-    signingCallBack: (callBackParams: PresentationSignCallBackParams) => IVerifiablePresentation,
+    signingCallBack: (callBackParams: PresentationSignCallBackParams) => Promise<IVerifiablePresentation>,
     options: PresentationSignOptions
   ): Promise<IVerifiablePresentation> {
     const { holder, signatureOptions, proofOptions } = options;

--- a/lib/PEXv1.ts
+++ b/lib/PEXv1.ts
@@ -217,7 +217,9 @@ export class PEXv1 {
   public async verifiablePresentationFromAsync(
     presentationDefinition: PresentationDefinitionV1,
     selectedCredentials: (IVerifiableCredential | JwtWrappedVerifiableCredential | string)[],
-    signingCallBack: (callBackParams: PresentationSignCallBackParams) => Promise<IVerifiablePresentation>,
+    signingCallBack: (
+      callBackParams: PresentationSignCallBackParams
+    ) => Promise<IVerifiablePresentation> | IVerifiablePresentation,
     options: PresentationSignOptions
   ): Promise<IVerifiablePresentation> {
     const { holder, signatureOptions, proofOptions } = options;

--- a/lib/PEXv2.ts
+++ b/lib/PEXv2.ts
@@ -202,7 +202,9 @@ export class PEXv2 {
   public async verifiablePresentationFromAsync(
     presentationDefinition: PresentationDefinitionV2,
     selectedCredentials: (IVerifiableCredential | JwtWrappedVerifiableCredential | string)[],
-    signingCallBack: (callBackParams: PresentationSignCallBackParams) => Promise<IVerifiablePresentation>,
+    signingCallBack: (
+      callBackParams: PresentationSignCallBackParams
+    ) => Promise<IVerifiablePresentation> | IVerifiablePresentation,
     options: PresentationSignOptions
   ): Promise<IVerifiablePresentation> {
     const { holder, signatureOptions, proofOptions } = options;

--- a/lib/PEXv2.ts
+++ b/lib/PEXv2.ts
@@ -202,7 +202,7 @@ export class PEXv2 {
   public async verifiablePresentationFromAsync(
     presentationDefinition: PresentationDefinitionV2,
     selectedCredentials: (IVerifiableCredential | JwtWrappedVerifiableCredential | string)[],
-    signingCallBack: (callBackParams: PresentationSignCallBackParams) => IVerifiablePresentation,
+    signingCallBack: (callBackParams: PresentationSignCallBackParams) => Promise<IVerifiablePresentation>,
     options: PresentationSignOptions
   ): Promise<IVerifiablePresentation> {
     const { holder, signatureOptions, proofOptions } = options;

--- a/test/PEXv1.spec.ts
+++ b/test/PEXv1.spec.ts
@@ -7,8 +7,8 @@ import { PEXv1, Validated } from '../lib';
 
 import {
   assertedMockCallback,
-  assertedMockCallbackWithoutProofType,
-  getErrorThrown,
+  getAsyncCallbackWithoutProofType,
+  getAsyncErrorThrown,
   getProofOptionsMock,
   getSingatureOptionsMock,
 } from './test_data/PresentationSignUtilMock';
@@ -147,7 +147,7 @@ describe('evaluate', () => {
       pex.verifiablePresentationFromAsync(
         pdSchema.presentation_definition,
         vpSimple.verifiableCredential,
-        assertedMockCallbackWithoutProofType,
+        getAsyncCallbackWithoutProofType,
         {
           proofOptions,
           signatureOptions: getSingatureOptionsMock(),
@@ -166,7 +166,7 @@ describe('evaluate', () => {
       pex.verifiablePresentationFromAsync(
         pdSchema.presentation_definition,
         vpSimple.verifiableCredential,
-        getErrorThrown,
+        getAsyncErrorThrown,
         {
           proofOptions: getProofOptionsMock(),
           signatureOptions: getSingatureOptionsMock(),

--- a/test/PEXv2.spec.ts
+++ b/test/PEXv2.spec.ts
@@ -9,6 +9,7 @@ import { PresentationDefinitionV2VB } from '../lib/validation';
 import {
   assertedMockCallback,
   assertedMockCallbackWithoutProofType,
+  getAsyncCallbackWithoutProofType,
   getProofOptionsMock,
   getSingatureOptionsMock,
 } from './test_data/PresentationSignUtilMock';
@@ -311,7 +312,7 @@ describe('evaluate', () => {
       pex.verifiablePresentationFromAsync(
         pdSchema.presentation_definition,
         vpSimple.verifiableCredential,
-        assertedMockCallbackWithoutProofType,
+        getAsyncCallbackWithoutProofType,
         {
           proofOptions,
           signatureOptions: getSingatureOptionsMock(),

--- a/test/test_data/PresentationSignUtilMock.ts
+++ b/test/test_data/PresentationSignUtilMock.ts
@@ -47,6 +47,10 @@ export function getErrorThrown(): IVerifiablePresentation {
   throw new Error('Could not sign because of missing fields');
 }
 
+export async function getAsyncErrorThrown(): Promise<IVerifiablePresentation> {
+  throw new Error('Could not sign because of missing fields');
+}
+
 export async function getAsyncCallbackWithoutProofType(
   callbackParams: PresentationSignCallBackParams
 ): Promise<IVerifiablePresentation> {


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix for typing

- **What is the current behavior?** (You can also link to an open issue here)
The expected return type of the `signingCallBack` in the `PEXv1` and `PEXv2` classes is `IVerifiablePresentation`, while the `PEX` class has the expected return type as `Promise<IVerifiablePresentation>`. As the `fromAsync` method is introduced to work with async signing methods,  I believe these methods should also expect a promise result.

- **What is the new behavior (if this is a feature change)?**

The return type of the `signingCallBack` in the `PEXv1` and `PEXv2` classes is `IVerifiablePresentation`

- **Other information**:
