### PR TITLE
feat: added more properties in pex2 schema

### DIFF
--- a/lib/validation/core/presentationDefinitionSchema.ts
+++ b/lib/validation/core/presentationDefinitionSchema.ts
@@ -412,7 +412,7 @@ export class PresentationDefinitionSchema {
         format: {
           type: 'object',
           patternProperties: {
-            '^jwt$|^jwt_vc$|^jwt_vp$': {
+            '^jwt$|^jwt_vc$|^jwt_vp$|^mso_mdoc$': {
               type: 'object',
               properties: {
                 alg: {
@@ -499,6 +499,7 @@ export class PresentationDefinitionSchema {
               type: 'array',
               items: { type: 'string' },
             },
+            format: { $ref: '#/definitions/format' },
             constraints: {
               type: 'object',
               properties: {
@@ -600,6 +601,7 @@ export class PresentationDefinitionSchema {
                   items: { type: 'string' },
                 },
                 purpose: { type: 'string' },
+                intent_to_retain: { type: 'boolean' },
                 filter: { $ref: 'http://json-schema.org/schema#' },
               },
               required: ['path'],
@@ -613,6 +615,7 @@ export class PresentationDefinitionSchema {
                   items: { type: 'string' },
                 },
                 purpose: { type: 'string' },
+                intent_to_retain: { type: 'boolean' },
                 filter: { $ref: 'http://json-schema.org/schema#' },
                 predicate: {
                   type: 'string',


### PR DESCRIPTION
* included `mso_mdoc` as valid `format` identifier (https://openid.net/specs/openid-4-verifiable-presentations-1_0.html#name-iso-mobile-driving-license-)
* added `format` as `input_descriptor`'s property (https://identity.foundation/presentation-exchange/spec/v2.0.0/#presentation-definition-in-an-envelope)
* added `intent_to_retain` as `field` property (https://identity.foundation/presentation-exchange/spec/v2.0.0/#retention-feature)
