### PR TITLE
add `name` property to `field` definition

### DIFF
--- a/resources/presentation_definition_v2.schema.json
+++ b/resources/presentation_definition_v2.schema.json
@@ -310,6 +310,9 @@
             },
             "filter": {
               "$ref": "http://json-schema.org/schema#"
+            },
+            "name": {
+              "type": "string"
             }
           },
           "required": [
@@ -343,6 +346,9 @@
                 "required",
                 "preferred"
               ]
+            },
+            "name": {
+              "type": "string"
             }
           },
           "required": [


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
adds `name` property to `field` definition in pd v2 json schema

- **What is the current behavior?** (You can also link to an open issue here)
using `evaluatePresentation` method fails when presentation definition includes a `field` object with the `name` property in it

- **What is the new behavior (if this is a feature change)?**

- **Other information**:

Reference from the [PEX V2 spec](https://identity.foundation/presentation-exchange/#input-descriptor-object)

<img width="825" alt="image" src="https://github.com/Sphereon-Opensource/pex-openapi/assets/4887440/aea7a712-3442-4924-8486-7b5dc63ac3ae">