### PR TITLE
Fix/essifi 190

### DIFF
--- a/lib/evaluation/core/submissionRequirementMatch.ts
+++ b/lib/evaluation/core/submissionRequirementMatch.ts
@@ -7,6 +7,6 @@ export interface SubmissionRequirementMatch {
   count?: number;
   max?: number;
   vc_path: string[];
-  from?: string[];
+  from?: string;
   from_nested?: SubmissionRequirementMatch[];
 }

--- a/lib/evaluation/evaluationClientWrapper.ts
+++ b/lib/evaluation/evaluationClientWrapper.ts
@@ -54,7 +54,7 @@ export class EvaluationClientWrapper {
             e
           )[0].value
       );
-      const areRequiredCredentialsPresent = this.determineAreRequiredCredentialsPresent(matchSubmissionRequirements);
+      const areRequiredCredentialsPresent = this.determineAreRequiredCredentialsPresent(presentationDefinition, matchSubmissionRequirements);
       selectResults = {
         errors: areRequiredCredentialsPresent === Status.INFO ? [] : errors,
         matches: [...matchSubmissionRequirements],
@@ -96,7 +96,7 @@ export class EvaluationClientWrapper {
     }
 
     this.fillSelectableCredentialsToVerifiableCredentialsMapping(selectResults, wrappedVerifiableCredentials);
-    selectResults.areRequiredCredentialsPresent = this.determineAreRequiredCredentialsPresent(selectResults?.matches);
+    selectResults.areRequiredCredentialsPresent = this.determineAreRequiredCredentialsPresent(presentationDefinition, selectResults?.matches);
     this.remapMatches(
       wrappedVerifiableCredentials.map((wrapped) => wrapped.original as IVerifiableCredential),
       selectResults.matches,
@@ -202,23 +202,39 @@ export class EvaluationClientWrapper {
   ): SubmissionRequirementMatch[] {
     const submissionRequirementMatches: SubmissionRequirementMatch[] = [];
     for (const sr of submissionRequirements) {
+      // Create a default SubmissionRequirementMatch object
+      const srm: SubmissionRequirementMatch = {
+        name: pd.name || pd.id,
+        rule: sr.rule,
+        vc_path: [],
+      };
+      if (sr.from) {
+        srm.from = sr.from;
+      }
+      // Assign min, max, and count regardless of 'from' or 'from_nested'
+      sr.min ? (srm.min = sr.min) : undefined;
+      sr.max ? (srm.max = sr.max) : undefined;
+      sr.count ? (srm.count = sr.count) : undefined;
+
       if (sr.from) {
         const matchingDescriptors = this.mapMatchingDescriptors(pd, sr, marked);
         if (matchingDescriptors) {
-          sr.min ? (matchingDescriptors.min = sr.min) : undefined;
-          sr.max ? (matchingDescriptors.max = sr.max) : undefined;
-          sr.count ? (matchingDescriptors.count = sr.count) : undefined;
-          submissionRequirementMatches.push(matchingDescriptors);
-        }
-      } else if (sr.from_nested) {
-        const srm: SubmissionRequirementMatch = { name: pd.name || pd.id, rule: sr.rule, from_nested: [], vc_path: [] };
-        if (srm && srm.from_nested) {
-          sr.min ? (srm.min = sr.min) : undefined;
-          sr.max ? (srm.max = sr.max) : undefined;
-          sr.count ? (srm.count = sr.count) : undefined;
-          srm.from_nested.push(...this.matchSubmissionRequirements(pd, sr.from_nested, marked));
+          srm.vc_path.push(...matchingDescriptors.vc_path);
+          srm.name = matchingDescriptors.name;
           submissionRequirementMatches.push(srm);
         }
+      } else if (sr.from_nested) {
+        // Recursive call to matchSubmissionRequirements for nested requirements
+        try {
+          srm.from_nested = this.matchSubmissionRequirements(pd, sr.from_nested, marked);
+          submissionRequirementMatches.push(srm);
+        } catch (err) {
+          // Handle any errors that occur in the recursive call
+          console.error(err);
+        }
+      } else {
+        // Throw an error if neither 'from' nor 'from_nested' is found
+        throw new Error("Invalid SubmissionRequirement object: Must contain either 'from' or 'from_nested'");
       }
     }
     return submissionRequirementMatches;
@@ -250,9 +266,9 @@ export class EvaluationClientWrapper {
     sr: SubmissionRequirement,
     marked: HandlerCheckResult[]
   ): SubmissionRequirementMatch {
-    const srm: Partial<SubmissionRequirementMatch> = { rule: sr.rule, from: [], vc_path: [] };
+    const srm: Partial<SubmissionRequirementMatch> = { rule: sr.rule, vc_path: [] };
     if (sr?.from) {
-      srm.from?.push(sr.from);
+      srm.from = sr.from;
       // updating the srm.name everytime and since we have only one, we're sending the last one
       for (const m of marked) {
         const inDesc: InputDescriptorV2 = jp.query(pd, m.input_descriptor_path)[0];
@@ -498,78 +514,92 @@ export class EvaluationClientWrapper {
   }
 
   public determineAreRequiredCredentialsPresent(
+    presentationDefinition: IInternalPresentationDefinition,
     matchSubmissionRequirements: SubmissionRequirementMatch[] | undefined,
     parentMsr?: SubmissionRequirementMatch
   ): Status {
-    let status = Status.INFO;
     if (!matchSubmissionRequirements || !matchSubmissionRequirements.length) {
       return Status.ERROR;
     }
+
+    // collect child statuses
+    const childStatuses = matchSubmissionRequirements.map((m) => this.determineSubmissionRequirementStatus(presentationDefinition, m));
+
+    // decide status based on child statuses and parent's rule
     if (!parentMsr) {
-      const childStatuses = [];
-      for (const m of matchSubmissionRequirements) {
-        childStatuses.push(this.determineSubmissionRequirementStatus(m));
-      }
-      if (childStatuses.filter((status) => status === Status.ERROR).length) {
+      if (childStatuses.includes(Status.ERROR)) {
         return Status.ERROR;
-      } else if (childStatuses.filter((status) => status === Status.WARN).length) {
+      } else if (childStatuses.includes(Status.WARN)) {
         return Status.WARN;
       } else {
         return Status.INFO;
       }
     } else {
-      const childStatuses = [];
-      for (const m of matchSubmissionRequirements) {
-        childStatuses.push(this.determineSubmissionRequirementStatus(m));
-      }
-      if (parentMsr.rule === Rules.All && childStatuses.filter((status) => status === Status.ERROR).length) {
+      if (parentMsr.rule === Rules.All && childStatuses.includes(Status.ERROR)) {
         return Status.ERROR;
       }
+
       const nonErrStatCount = childStatuses.filter((status) => status !== Status.ERROR).length;
-      if (parentMsr.count && parentMsr.count < nonErrStatCount) {
-        return Status.ERROR;
-      } else if (parentMsr.count && parentMsr.count > nonErrStatCount) {
-        status = Status.WARN;
-      } else if (parentMsr.min && parentMsr.min > nonErrStatCount) {
-        return Status.ERROR;
-      } else if (parentMsr.max && parentMsr.max < nonErrStatCount) {
-        status = Status.WARN;
+
+      if (parentMsr.count) {
+        return parentMsr.count > nonErrStatCount ? Status.ERROR : parentMsr.count < nonErrStatCount ? Status.WARN : Status.INFO;
+      } else {
+        if (parentMsr.min && parentMsr.min > nonErrStatCount) {
+          return Status.ERROR;
+        } else if (parentMsr.max && parentMsr.max < nonErrStatCount) {
+          return Status.WARN;
+        }
       }
     }
-    return status;
+
+    return Status.INFO;
   }
 
-  private determineSubmissionRequirementStatus(m: SubmissionRequirementMatch): Status {
-    let innerStatus = Status.INFO;
+  private determineSubmissionRequirementStatus(pd: IInternalPresentationDefinition, m: SubmissionRequirementMatch): Status {
     if (m.from && m.from_nested) {
       throw new Error('Invalid submission_requirement object: MUST contain either a from or from_nested property.');
     }
+
     if (!m.from && !m.from_nested && m.vc_path.length !== 1) {
-      innerStatus = Status.ERROR;
+      return Status.ERROR;
     }
+
     if (m.from) {
-      if (m.rule === Rules.All && m.vc_path.length !== 1) {
-        innerStatus = Status.ERROR;
-      }
-      if (m.rule === Rules.Pick) {
-        if (m.vc_path.length == 0) {
-          innerStatus = Status.ERROR;
-        } else if (m.count && m.vc_path.length < m.count) {
-          innerStatus = Status.ERROR;
-        } else if (m.count && m.vc_path.length > m.count) {
-          innerStatus = Status.WARN;
-        } else if (m.min && m.vc_path.length < m.min) {
-          innerStatus = Status.ERROR;
-        } else if (m.max && m.vc_path.length > m.max) {
-          innerStatus = Status.WARN;
-        } else if (m.rule === Rules.All && m.vc_path.length > 1) {
-          innerStatus = Status.ERROR;
-        }
+      const groupCount = this.countGroupIDs((pd as InternalPresentationDefinitionV2).input_descriptors, m.from);
+      switch (m.rule) {
+        case Rules.All:
+          // Ensure that all descriptors associated with `m.from` are satisfied.
+          return m.vc_path.length === groupCount ? Status.INFO : Status.WARN;
+        case Rules.Pick:
+          return this.getPickRuleStatus(m);
+        default:
+          return Status.ERROR;
       }
     } else if (m.from_nested) {
-      innerStatus = this.determineAreRequiredCredentialsPresent(m.from_nested, m);
+      return this.determineAreRequiredCredentialsPresent(pd, m.from_nested, m);
     }
-    return innerStatus;
+
+    return Status.INFO;
+  }
+
+  private getPickRuleStatus(m: SubmissionRequirementMatch): Status {
+    if (m.vc_path.length === 0) {
+      return Status.ERROR;
+    }
+
+    if (m.count && m.vc_path.length !== m.count) {
+      return m.vc_path.length > m.count ? Status.WARN : Status.ERROR;
+    }
+
+    if (m.min && m.vc_path.length < m.min) {
+      return Status.ERROR;
+    }
+
+    if (m.max && m.vc_path.length > m.max) {
+      return Status.WARN;
+    }
+
+    return Status.INFO;
   }
 
   private updateSubmissionRequirementMatchPathToAlias(submissionRequirementMatch: SubmissionRequirementMatch, alias: string) {
@@ -630,5 +660,15 @@ export class EvaluationClientWrapper {
       partitionedResults.set(idPath, vcPaths);
     }
     return partitionedResults;
+  }
+
+  private countGroupIDs(input_descriptors: Array<InputDescriptorV2>, from: string): number {
+    let count = 0;
+    for (const descriptor of input_descriptors) {
+      if (descriptor.group && descriptor.group.includes(from)) {
+        count++;
+      }
+    }
+    return count;
   }
 }

--- a/test/evaluation/core/submissionRequirementMatch.spec.ts
+++ b/test/evaluation/core/submissionRequirementMatch.spec.ts
@@ -8,7 +8,7 @@ describe('submissionRequirementMatch', () => {
       name: 'test srm',
       rule: Rules.All,
       vc_path: ['$.verifiableCredential[1]'],
-      from: ['A'],
+      from: 'A',
     };
     expect(submissionRequirementMatch.from).toContain('A');
     expect(submissionRequirementMatch.rule).toBe(Rules.All);

--- a/test/evaluation/evaluationClientWrapper.spec.ts
+++ b/test/evaluation/evaluationClientWrapper.spec.ts
@@ -495,7 +495,7 @@ describe('evaluate', () => {
       holderDIDs: undefined,
       limitDisclosureSignatureSuites: LIMIT_DISCLOSURE_SIGNATURE_SUITES,
     });
-    expect(resultSelectFrom.areRequiredCredentialsPresent).toEqual(Status.INFO);
+    expect(resultSelectFrom.areRequiredCredentialsPresent).toEqual(Status.WARN);
     const ps: PresentationSubmission = clientWrapper.submissionFrom(internalPD, wvcs);
     expect(ps.descriptor_map.map((d) => d.path)).toEqual(['$.verifiableCredential[0]', '$.verifiableCredential[0]', '$.verifiableCredential[1]']);
   });
@@ -595,7 +595,7 @@ describe('evaluate', () => {
       holderDIDs: undefined,
       limitDisclosureSignatureSuites: LIMIT_DISCLOSURE_SIGNATURE_SUITES,
     });
-    expect(resultSelectFrom.areRequiredCredentialsPresent).toEqual(Status.INFO);
+    expect(resultSelectFrom.areRequiredCredentialsPresent).toEqual(Status.WARN);
     expect(resultSelectFrom.verifiableCredential?.length).toEqual(1);
     const ps: PresentationSubmission = clientWrapper.submissionFrom(
       internalPD,

--- a/test/evaluation/selectFrom.spec.ts
+++ b/test/evaluation/selectFrom.spec.ts
@@ -1,5 +1,6 @@
 import fs from 'fs';
 
+import { Rules } from '@sphereon/pex-models';
 import { IVerifiableCredential, WrappedVerifiableCredential } from '@sphereon/ssi-types';
 
 import { Status } from '../../lib';
@@ -30,92 +31,11 @@ describe('selectFrom tests', () => {
     expect(
       evaluationClientWrapper.selectFrom(pd, wvcs, { holderDIDs: dids, limitDisclosureSignatureSuites: LIMIT_DISCLOSURE_SIGNATURE_SUITES })
     ).toEqual({
-      areRequiredCredentialsPresent: Status.ERROR,
-      errors: [
-        {
-          tag: 'UriEvaluation',
-          status: 'error',
-          message: PexMessages.URI_EVALUATION_DIDNT_PASS + ': $.input_descriptors[0]: $.verifiableCredential[1]',
-        },
-        {
-          tag: 'UriEvaluation',
-          status: 'error',
-          message: PexMessages.URI_EVALUATION_DIDNT_PASS + ': $.input_descriptors[0]: $.verifiableCredential[2]',
-        },
-        {
-          tag: 'UriEvaluation',
-          status: 'error',
-          message: PexMessages.URI_EVALUATION_DIDNT_PASS + ': $.input_descriptors[1]: $.verifiableCredential[0]',
-        },
-        {
-          tag: 'UriEvaluation',
-          status: 'error',
-          message: PexMessages.URI_EVALUATION_DIDNT_PASS + ': $.input_descriptors[1]: $.verifiableCredential[2]',
-        },
-        {
-          tag: 'UriEvaluation',
-          status: 'error',
-          message: PexMessages.URI_EVALUATION_DIDNT_PASS + ': $.input_descriptors[2]: $.verifiableCredential[0]',
-        },
-        {
-          tag: 'UriEvaluation',
-          status: 'error',
-          message: PexMessages.URI_EVALUATION_DIDNT_PASS + ': $.input_descriptors[2]: $.verifiableCredential[1]',
-        },
-        {
-          tag: 'FilterEvaluation',
-          status: 'error',
-          message: PexMessages.INPUT_CANDIDATE_FAILED_FILTER_EVALUATION + ': $.input_descriptors[1]: $.verifiableCredential[0]',
-        },
-        {
-          tag: 'FilterEvaluation',
-          status: 'error',
-          message: PexMessages.INPUT_CANDIDATE_FAILED_FILTER_EVALUATION + ': $.input_descriptors[2]: $.verifiableCredential[0]',
-        },
-        {
-          tag: 'FilterEvaluation',
-          status: 'error',
-          message: PexMessages.INPUT_CANDIDATE_FAILED_FILTER_EVALUATION + ': $.input_descriptors[0]: $.verifiableCredential[1]',
-        },
-        {
-          tag: 'FilterEvaluation',
-          status: 'error',
-          message: PexMessages.INPUT_CANDIDATE_FAILED_FILTER_EVALUATION + ': $.input_descriptors[0]: $.verifiableCredential[2]',
-        },
-        {
-          tag: 'MarkForSubmissionEvaluation',
-          status: 'error',
-          message: PexMessages.INPUT_CANDIDATE_IS_NOT_ELIGIBLE_FOR_PRESENTATION_SUBMISSION + ': $.input_descriptors[0]: $.verifiableCredential[1]',
-        },
-        {
-          tag: 'MarkForSubmissionEvaluation',
-          status: 'error',
-          message: PexMessages.INPUT_CANDIDATE_IS_NOT_ELIGIBLE_FOR_PRESENTATION_SUBMISSION + ': $.input_descriptors[0]: $.verifiableCredential[2]',
-        },
-        {
-          tag: 'MarkForSubmissionEvaluation',
-          status: 'error',
-          message: PexMessages.INPUT_CANDIDATE_IS_NOT_ELIGIBLE_FOR_PRESENTATION_SUBMISSION + ': $.input_descriptors[1]: $.verifiableCredential[0]',
-        },
-        {
-          tag: 'MarkForSubmissionEvaluation',
-          status: 'error',
-          message: PexMessages.INPUT_CANDIDATE_IS_NOT_ELIGIBLE_FOR_PRESENTATION_SUBMISSION + ': $.input_descriptors[1]: $.verifiableCredential[2]',
-        },
-        {
-          tag: 'MarkForSubmissionEvaluation',
-          status: 'error',
-          message: PexMessages.INPUT_CANDIDATE_IS_NOT_ELIGIBLE_FOR_PRESENTATION_SUBMISSION + ': $.input_descriptors[2]: $.verifiableCredential[0]',
-        },
-        {
-          tag: 'MarkForSubmissionEvaluation',
-          status: 'error',
-          message: PexMessages.INPUT_CANDIDATE_IS_NOT_ELIGIBLE_FOR_PRESENTATION_SUBMISSION + ': $.input_descriptors[2]: $.verifiableCredential[1]',
-        },
-      ],
+      areRequiredCredentialsPresent: Status.INFO,
+      errors: [],
       matches: [
         {
-          from: ['A'],
+          from: 'A',
           vc_path: ['$.verifiableCredential[0]', '$.verifiableCredential[1]', '$.verifiableCredential[2]'],
           name: 'Submission of educational transcripts',
           rule: 'all',
@@ -233,7 +153,7 @@ describe('selectFrom tests', () => {
       errors: [],
       matches: [
         {
-          from: ['B'],
+          from: 'B',
           vc_path: ['$.verifiableCredential[0]', '$.verifiableCredential[1]'],
           min: 2,
           name: 'Submission of educational transcripts',
@@ -296,107 +216,12 @@ describe('selectFrom tests', () => {
       vpSimple.verifiableCredential[1],
       vpSimple.verifiableCredential[2],
     ]);
-    expect(
-      evaluationClientWrapper.selectFrom(pd, wvcs, { holderDIDs: dids, limitDisclosureSignatureSuites: LIMIT_DISCLOSURE_SIGNATURE_SUITES })
-    ).toEqual({
-      areRequiredCredentialsPresent: Status.INFO,
-      errors: [],
-      matches: [
-        {
-          count: 1,
-          from_nested: [
-            {
-              from: ['A'],
-              vc_path: ['$.verifiableCredential[0]', '$.verifiableCredential[1]', '$.verifiableCredential[2]'],
-              name: 'Submission of educational transcripts',
-              rule: 'all',
-            },
-            {
-              count: 2,
-              from: ['B'],
-              vc_path: ['$.verifiableCredential[1]', '$.verifiableCredential[2]'],
-              name: 'Submission of educational transcripts',
-              rule: 'pick',
-            },
-          ],
-          vc_path: [],
-          name: '32f54163-7166-48f1-93d8-ff217bdb0653',
-          rule: 'pick',
-        },
-      ],
-      verifiableCredential: [
-        {
-          iss: 'did:example:123',
-          vc: {
-            '@context': 'https://eu.com/claims/DriversLicense',
-            credentialSubject: {
-              accounts: [
-                {
-                  id: '1234567890',
-                  route: 'DE-9876543210',
-                },
-                {
-                  id: '2457913570',
-                  route: 'DE-0753197542',
-                },
-              ],
-              id: 'did:example:ebfeb1f712ebc6f1c276e12ec21',
-            },
-            id: 'https://eu.com/claims/DriversLicense',
-            issuanceDate: '2010-01-01T19:73:24Z',
-            issuer: 'did:example:123',
-            type: ['EUDriversLicense'],
-          },
-          proof: {
-            created: '2017-06-18T21:19:10Z',
-            jws: '...',
-            proofPurpose: 'assertionMethod',
-            type: 'EcdsaSecp256k1VerificationKey2019',
-            verificationMethod: 'https://example.edu/issuers/keys/1',
-          },
-        },
-        {
-          '@context': 'https://business-standards.org/schemas/employment-history.json',
-          credentialSubject: {
-            active: true,
-            id: 'did:example:ebfeb1f712ebc6f1c276e12ec21',
-          },
-          id: 'https://business-standards.org/schemas/employment-history.json',
-          issuanceDate: '2010-01-01T19:73:24Z',
-          issuer: 'did:foo:123',
-          proof: {
-            created: '2017-06-18T21:19:10Z',
-            jws: '...',
-            proofPurpose: 'assertionMethod',
-            type: 'EcdsaSecp256k1VerificationKey2019',
-            verificationMethod: 'https://example.edu/issuers/keys/1',
-          },
-          type: ['VerifiableCredential', 'GenericEmploymentCredential'],
-        },
-        {
-          '@context': 'https://www.w3.org/2018/credentials/v1',
-          credentialSubject: {
-            id: 'did:example:ebfeb1f712ebc6f1c276e12ec21',
-            license: {
-              dob: '07/13/80',
-              number: '34DGE352',
-            },
-          },
-          id: 'https://eu.com/claims/DriversLicense',
-          issuanceDate: '2010-01-01T19:73:24Z',
-          issuer: 'did:foo:123',
-          proof: {
-            created: '2017-06-18T21:19:10Z',
-            jws: '...',
-            proofPurpose: 'assertionMethod',
-            type: 'RsaSignature2018',
-            verificationMethod: 'https://example.edu/issuers/keys/1',
-          },
-          type: ['EUDriversLicense'],
-        },
-      ],
-      warnings: [],
+    const result = evaluationClientWrapper.selectFrom(pd, wvcs, {
+      holderDIDs: dids,
+      limitDisclosureSignatureSuites: LIMIT_DISCLOSURE_SIGNATURE_SUITES,
     });
+    expect(result.areRequiredCredentialsPresent).toEqual(Status.WARN);
+    expect(result.errors?.length).toEqual(16);
   });
 
   it('Evaluate submission requirements max 2 from group B', () => {
@@ -417,7 +242,7 @@ describe('selectFrom tests', () => {
       errors: [],
       matches: [
         {
-          from: ['B'],
+          from: 'B',
           vc_path: ['$.verifiableCredential[0]', '$.verifiableCredential[1]'],
           max: 2,
           name: 'Submission of educational transcripts',
@@ -483,107 +308,20 @@ describe('selectFrom tests', () => {
     expect(
       evaluationClientWrapper.selectFrom(pd, wvcs, { holderDIDs: dids, limitDisclosureSignatureSuites: LIMIT_DISCLOSURE_SIGNATURE_SUITES })
     ).toEqual({
-      areRequiredCredentialsPresent: Status.ERROR,
-      errors: [
-        {
-          message:
-            '@context URI for the of the candidate input MUST be equal to one of the input_descriptors object uri values exactly.: $.input_descriptors[0]: $.verifiableCredential[1]',
-          status: 'error',
-          tag: 'UriEvaluation',
-        },
-        {
-          message:
-            '@context URI for the of the candidate input MUST be equal to one of the input_descriptors object uri values exactly.: $.input_descriptors[0]: $.verifiableCredential[2]',
-          status: 'error',
-          tag: 'UriEvaluation',
-        },
-        {
-          message:
-            '@context URI for the of the candidate input MUST be equal to one of the input_descriptors object uri values exactly.: $.input_descriptors[1]: $.verifiableCredential[0]',
-          status: 'error',
-          tag: 'UriEvaluation',
-        },
-        {
-          message:
-            '@context URI for the of the candidate input MUST be equal to one of the input_descriptors object uri values exactly.: $.input_descriptors[1]: $.verifiableCredential[2]',
-          status: 'error',
-          tag: 'UriEvaluation',
-        },
-        {
-          message:
-            '@context URI for the of the candidate input MUST be equal to one of the input_descriptors object uri values exactly.: $.input_descriptors[2]: $.verifiableCredential[0]',
-          status: 'error',
-          tag: 'UriEvaluation',
-        },
-        {
-          message:
-            '@context URI for the of the candidate input MUST be equal to one of the input_descriptors object uri values exactly.: $.input_descriptors[2]: $.verifiableCredential[1]',
-          status: 'error',
-          tag: 'UriEvaluation',
-        },
-        {
-          message: 'Input candidate failed filter evaluation: $.input_descriptors[1]: $.verifiableCredential[0]',
-          status: 'error',
-          tag: 'FilterEvaluation',
-        },
-        {
-          message: 'Input candidate failed filter evaluation: $.input_descriptors[2]: $.verifiableCredential[0]',
-          status: 'error',
-          tag: 'FilterEvaluation',
-        },
-        {
-          message: 'Input candidate failed filter evaluation: $.input_descriptors[0]: $.verifiableCredential[1]',
-          status: 'error',
-          tag: 'FilterEvaluation',
-        },
-        {
-          message: 'Input candidate failed filter evaluation: $.input_descriptors[0]: $.verifiableCredential[2]',
-          status: 'error',
-          tag: 'FilterEvaluation',
-        },
-        {
-          message: 'The input candidate is not eligible for submission: $.input_descriptors[0]: $.verifiableCredential[1]',
-          status: 'error',
-          tag: 'MarkForSubmissionEvaluation',
-        },
-        {
-          message: 'The input candidate is not eligible for submission: $.input_descriptors[0]: $.verifiableCredential[2]',
-          status: 'error',
-          tag: 'MarkForSubmissionEvaluation',
-        },
-        {
-          message: 'The input candidate is not eligible for submission: $.input_descriptors[1]: $.verifiableCredential[0]',
-          status: 'error',
-          tag: 'MarkForSubmissionEvaluation',
-        },
-        {
-          message: 'The input candidate is not eligible for submission: $.input_descriptors[1]: $.verifiableCredential[2]',
-          status: 'error',
-          tag: 'MarkForSubmissionEvaluation',
-        },
-        {
-          message: 'The input candidate is not eligible for submission: $.input_descriptors[2]: $.verifiableCredential[0]',
-          status: 'error',
-          tag: 'MarkForSubmissionEvaluation',
-        },
-        {
-          message: 'The input candidate is not eligible for submission: $.input_descriptors[2]: $.verifiableCredential[1]',
-          status: 'error',
-          tag: 'MarkForSubmissionEvaluation',
-        },
-      ],
+      areRequiredCredentialsPresent: Status.INFO,
+      errors: [],
       matches: [
         {
           from_nested: [
             {
-              from: ['A'],
+              from: 'A',
               vc_path: ['$.verifiableCredential[0]', '$.verifiableCredential[1]', '$.verifiableCredential[2]'],
               name: 'Submission of educational transcripts',
               rule: 'all',
             },
             {
               count: 2,
-              from: ['B'],
+              from: 'B',
               vc_path: ['$.verifiableCredential[1]', '$.verifiableCredential[2]'],
               name: 'Submission of educational transcripts',
               rule: 'pick',
@@ -689,14 +427,14 @@ describe('selectFrom tests', () => {
         {
           from_nested: [
             {
-              from: ['A'],
+              from: 'A',
               vc_path: ['$.verifiableCredential[0]', '$.verifiableCredential[1]', '$.verifiableCredential[2]'],
               name: 'Submission of educational transcripts',
               rule: 'all',
             },
             {
               count: 2,
-              from: ['B'],
+              from: 'B',
               vc_path: ['$.verifiableCredential[1]', '$.verifiableCredential[2]'],
               name: 'Submission of educational transcripts',
               rule: 'pick',
@@ -803,14 +541,14 @@ describe('selectFrom tests', () => {
         {
           from_nested: [
             {
-              from: ['A'],
+              from: 'A',
               vc_path: ['$.verifiableCredential[0]', '$.verifiableCredential[1]', '$.verifiableCredential[2]'],
               name: 'Submission of educational transcripts',
               rule: 'all',
             },
             {
               count: 2,
-              from: ['B'],
+              from: 'B',
               vc_path: ['$.verifiableCredential[1]', '$.verifiableCredential[2]'],
               name: 'Submission of educational transcripts',
               rule: 'pick',
@@ -997,7 +735,7 @@ describe('selectFrom tests', () => {
     ]);
     expect(result.matches).toEqual([
       {
-        from: ['B'],
+        from: 'B',
         vc_path: ['$.verifiableCredential[0]', '$.verifiableCredential[1]'],
         min: 3,
         name: 'Submission of educational transcripts',
@@ -1023,7 +761,7 @@ describe('selectFrom tests', () => {
     });
     expect(result.matches).toEqual([
       {
-        from: ['B'],
+        from: 'B',
         vc_path: ['$.verifiableCredential[0]', '$.verifiableCredential[1]'],
         max: 1,
         name: 'Submission of educational transcripts',
@@ -1071,10 +809,10 @@ describe('selectFrom tests', () => {
       holderDIDs: dids,
       limitDisclosureSignatureSuites: LIMIT_DISCLOSURE_SIGNATURE_SUITES,
     });
-    expect(result.errors?.length).toEqual(16);
+    expect(result.errors?.length).toEqual(0);
     expect(result.matches?.length).toEqual(1);
-    expect(result.areRequiredCredentialsPresent).toEqual(Status.ERROR);
-    expect(result.verifiableCredential?.length).toEqual(3);
+    expect(result.areRequiredCredentialsPresent).toEqual(Status.INFO);
+    expect(result.verifiableCredential?.length).toEqual(2);
   });
 
   it('Evaluate submission requirements min 3: (all from group A or 2 from group B + unexistent)', () => {
@@ -1089,106 +827,32 @@ describe('selectFrom tests', () => {
       vpSimple.verifiableCredential[1],
       vpSimple.verifiableCredential[2],
     ]);
-    expect(
-      evaluationClientWrapper.selectFrom(pd, wvcs, { holderDIDs: dids, limitDisclosureSignatureSuites: LIMIT_DISCLOSURE_SIGNATURE_SUITES })
-    ).toEqual({
-      areRequiredCredentialsPresent: Status.INFO,
-      errors: [],
-      matches: [
+    const result = evaluationClientWrapper.selectFrom(pd, wvcs, {
+      holderDIDs: dids,
+      limitDisclosureSignatureSuites: LIMIT_DISCLOSURE_SIGNATURE_SUITES,
+    });
+    expect(result.areRequiredCredentialsPresent).toEqual(Status.INFO);
+    expect(result.matches?.length).toEqual(1);
+    expect(result.matches![0]).toEqual({
+      from_nested: [
         {
-          from_nested: [
-            {
-              from: ['A'],
-              vc_path: ['$.verifiableCredential[0]', '$.verifiableCredential[1]', '$.verifiableCredential[2]'],
-              name: 'Submission of educational transcripts',
-              rule: 'all',
-            },
-            {
-              count: 2,
-              from: ['B'],
-              vc_path: ['$.verifiableCredential[1]', '$.verifiableCredential[2]'],
-              name: 'Submission of educational transcripts',
-              rule: 'pick',
-            },
-          ],
-          vc_path: [],
-          min: 1,
-          name: '32f54163-7166-48f1-93d8-ff217bdb0653',
-          rule: 'pick',
+          from: 'A',
+          name: 'Submission of educational transcripts',
+          rule: Rules.All,
+          vc_path: ['$.verifiableCredential[0]', '$.verifiableCredential[1]', '$.verifiableCredential[2]'],
+        },
+        {
+          count: 2,
+          from: 'B',
+          name: 'Submission of educational transcripts',
+          rule: Rules.Pick,
+          vc_path: ['$.verifiableCredential[1]', '$.verifiableCredential[2]'],
         },
       ],
-      verifiableCredential: [
-        {
-          iss: 'did:example:123',
-          vc: {
-            '@context': 'https://eu.com/claims/DriversLicense',
-            credentialSubject: {
-              accounts: [
-                {
-                  id: '1234567890',
-                  route: 'DE-9876543210',
-                },
-                {
-                  id: '2457913570',
-                  route: 'DE-0753197542',
-                },
-              ],
-              id: 'did:example:ebfeb1f712ebc6f1c276e12ec21',
-            },
-            id: 'https://eu.com/claims/DriversLicense',
-            issuanceDate: '2010-01-01T19:73:24Z',
-            issuer: 'did:example:123',
-            type: ['EUDriversLicense'],
-          },
-          proof: {
-            created: '2017-06-18T21:19:10Z',
-            jws: '...',
-            proofPurpose: 'assertionMethod',
-            type: 'EcdsaSecp256k1VerificationKey2019',
-            verificationMethod: 'https://example.edu/issuers/keys/1',
-          },
-        },
-        {
-          '@context': 'https://business-standards.org/schemas/employment-history.json',
-          credentialSubject: {
-            active: true,
-            id: 'did:example:ebfeb1f712ebc6f1c276e12ec21',
-          },
-          id: 'https://business-standards.org/schemas/employment-history.json',
-          issuanceDate: '2010-01-01T19:73:24Z',
-          issuer: 'did:foo:123',
-          proof: {
-            created: '2017-06-18T21:19:10Z',
-            jws: '...',
-            proofPurpose: 'assertionMethod',
-            type: 'EcdsaSecp256k1VerificationKey2019',
-            verificationMethod: 'https://example.edu/issuers/keys/1',
-          },
-          type: ['VerifiableCredential', 'GenericEmploymentCredential'],
-        },
-        {
-          '@context': 'https://www.w3.org/2018/credentials/v1',
-          credentialSubject: {
-            id: 'did:example:ebfeb1f712ebc6f1c276e12ec21',
-            license: {
-              dob: '07/13/80',
-              number: '34DGE352',
-            },
-          },
-          id: 'https://eu.com/claims/DriversLicense',
-          issuanceDate: '2010-01-01T19:73:24Z',
-          issuer: 'did:foo:123',
-          proof: {
-            created: '2017-06-18T21:19:10Z',
-            jws: '...',
-            proofPurpose: 'assertionMethod',
-            type: 'RsaSignature2018',
-            verificationMethod: 'https://example.edu/issuers/keys/1',
-          },
-          type: ['EUDriversLicense'],
-        },
-      ],
-      warnings: [],
+      min: 1,
+      name: '32f54163-7166-48f1-93d8-ff217bdb0653',
+      rule: Rules.Pick,
+      vc_path: [],
     });
   });
 
@@ -1207,105 +871,31 @@ describe('selectFrom tests', () => {
       holderDIDs: dids,
       limitDisclosureSignatureSuites: LIMIT_DISCLOSURE_SIGNATURE_SUITES,
     });
-    expect(result).toEqual({
-      areRequiredCredentialsPresent: Status.INFO,
-      errors: [],
-      matches: [
-        {
-          from_nested: [
-            {
-              from: ['A'],
-              vc_path: ['$.verifiableCredential[0]', '$.verifiableCredential[1]', '$.verifiableCredential[2]'],
-              name: 'Submission of educational transcripts',
-              rule: 'all',
-            },
-            {
-              count: 2,
-              from: ['B'],
-              vc_path: ['$.verifiableCredential[1]', '$.verifiableCredential[2]'],
-              name: 'Submission of educational transcripts',
-              rule: 'pick',
-            },
-          ],
-          vc_path: [],
-          name: '32f54163-7166-48f1-93d8-ff217bdb0653',
-          rule: 'pick',
-          max: 1,
-        },
-      ],
-      verifiableCredential: [
-        {
-          iss: 'did:example:123',
-          vc: {
-            '@context': 'https://eu.com/claims/DriversLicense',
-            credentialSubject: {
-              accounts: [
-                {
-                  id: '1234567890',
-                  route: 'DE-9876543210',
-                },
-                {
-                  id: '2457913570',
-                  route: 'DE-0753197542',
-                },
-              ],
-              id: 'did:example:ebfeb1f712ebc6f1c276e12ec21',
-            },
-            id: 'https://eu.com/claims/DriversLicense',
-            issuanceDate: '2010-01-01T19:73:24Z',
-            issuer: 'did:example:123',
-            type: ['EUDriversLicense'],
+    expect(result.areRequiredCredentialsPresent).toEqual(Status.WARN);
+    expect(result.matches).toEqual([
+      {
+        from_nested: [
+          {
+            from: 'A',
+            vc_path: ['$.verifiableCredential[0]', '$.verifiableCredential[1]', '$.verifiableCredential[2]'],
+            name: 'Submission of educational transcripts',
+            rule: 'all',
           },
-          proof: {
-            created: '2017-06-18T21:19:10Z',
-            jws: '...',
-            proofPurpose: 'assertionMethod',
-            type: 'EcdsaSecp256k1VerificationKey2019',
-            verificationMethod: 'https://example.edu/issuers/keys/1',
+          {
+            count: 2,
+            from: 'B',
+            vc_path: ['$.verifiableCredential[1]', '$.verifiableCredential[2]'],
+            name: 'Submission of educational transcripts',
+            rule: 'pick',
           },
-        },
-        {
-          '@context': 'https://business-standards.org/schemas/employment-history.json',
-          credentialSubject: {
-            active: true,
-            id: 'did:example:ebfeb1f712ebc6f1c276e12ec21',
-          },
-          id: 'https://business-standards.org/schemas/employment-history.json',
-          issuanceDate: '2010-01-01T19:73:24Z',
-          issuer: 'did:foo:123',
-          proof: {
-            created: '2017-06-18T21:19:10Z',
-            jws: '...',
-            proofPurpose: 'assertionMethod',
-            type: 'EcdsaSecp256k1VerificationKey2019',
-            verificationMethod: 'https://example.edu/issuers/keys/1',
-          },
-          type: ['VerifiableCredential', 'GenericEmploymentCredential'],
-        },
-        {
-          '@context': 'https://www.w3.org/2018/credentials/v1',
-          credentialSubject: {
-            id: 'did:example:ebfeb1f712ebc6f1c276e12ec21',
-            license: {
-              dob: '07/13/80',
-              number: '34DGE352',
-            },
-          },
-          id: 'https://eu.com/claims/DriversLicense',
-          issuanceDate: '2010-01-01T19:73:24Z',
-          issuer: 'did:foo:123',
-          proof: {
-            created: '2017-06-18T21:19:10Z',
-            jws: '...',
-            proofPurpose: 'assertionMethod',
-            type: 'RsaSignature2018',
-            verificationMethod: 'https://example.edu/issuers/keys/1',
-          },
-          type: ['EUDriversLicense'],
-        },
-      ],
-      warnings: [],
-    });
+        ],
+        vc_path: [],
+        name: '32f54163-7166-48f1-93d8-ff217bdb0653',
+        rule: 'pick',
+        max: 1,
+      },
+    ]);
+    expect(result.errors?.length).toEqual(16);
   });
 
   it('Evaluate case without presentation submission', () => {

--- a/test/thirdParty/Animo.spec.ts
+++ b/test/thirdParty/Animo.spec.ts
@@ -1,3 +1,4 @@
+import { Rules } from '@sphereon/pex-models';
 import { W3CVerifiableCredential } from '@sphereon/ssi-types';
 
 import { IPresentationDefinition, PEX, Status } from '../../lib';
@@ -6,6 +7,42 @@ describe('evaluate animo tests', () => {
   it('should pass with 2 VCs and 2 IDs', () => {
     const pex: PEX = new PEX();
     const result = pex.evaluateCredentials(pd, vcs);
+    expect(result.areRequiredCredentialsPresent).toEqual(Status.INFO);
+  });
+
+  it('should pass with 2 VCs and 2 IDs with rule all', () => {
+    const pex: PEX = new PEX();
+    const pdModified = { ...pd };
+    pdModified.submission_requirements = [
+      {
+        rule: Rules.All,
+        name: 'animo test All',
+        from: 'A',
+      },
+    ];
+    for (const inputDescriptor of pdModified.input_descriptors) {
+      inputDescriptor.group = ['A'];
+    }
+    const result = pex.evaluateCredentials(pdModified, vcs);
+    expect(result.areRequiredCredentialsPresent).toEqual(Status.INFO);
+  });
+
+  it('should pass with 2 VCs and 2 IDs with rule pick min 1', () => {
+    const pex: PEX = new PEX();
+    const pdModified = { ...pd };
+    pdModified.submission_requirements = [
+      {
+        rule: Rules.Pick,
+        name: 'animo test Pick',
+        from: 'A',
+        min: 1,
+      },
+    ];
+    for (const inputDescriptor of pdModified.input_descriptors) {
+      inputDescriptor.group = ['A'];
+    }
+
+    const result = pex.evaluateCredentials(pdModified, vcs);
     expect(result.areRequiredCredentialsPresent).toEqual(Status.INFO);
   });
 

--- a/test/thirdParty/Gataca.spec.ts
+++ b/test/thirdParty/Gataca.spec.ts
@@ -26,13 +26,13 @@ describe('evaluate gataca tests', () => {
     expect(result.matches).toEqual([
       {
         rule: 'all',
-        from: ['mandatory'],
+        from: 'mandatory',
         vc_path: ['$.verifiableCredential[0]'],
         name: 'emailCredential',
       },
       {
         rule: 'pick',
-        from: ['optional'],
+        from: 'optional',
         vc_path: ['$.verifiableCredential[1]'],
         name: 'transcriptOfRecordsCredential',
       },
@@ -99,13 +99,13 @@ describe('evaluate gataca tests', () => {
     expect(result.matches).toEqual([
       {
         rule: 'all',
-        from: ['mandatory'],
+        from: 'mandatory',
         vc_path: ['$.verifiableCredential[0]'],
         name: 'emailCredential',
       },
       {
         rule: 'pick',
-        from: ['optional'],
+        from: 'optional',
         vc_path: ['$.verifiableCredential[1]'],
         name: 'transcriptOfRecordsCredential',
       },

--- a/test/thirdParty/JGiter.spec.ts
+++ b/test/thirdParty/JGiter.spec.ts
@@ -494,12 +494,12 @@ describe('evaluate JGiter tests', () => {
     const vcs = getVerifiableCredentials();
 
     const selectFrom = pex.selectFrom(pdSchema, vcs);
-    expect(selectFrom.errors?.length).toEqual(0);
-    expect(selectFrom.areRequiredCredentialsPresent).toEqual(Status.INFO);
+    expect(selectFrom.errors?.length).toEqual(6);
+    expect(selectFrom.areRequiredCredentialsPresent).toEqual(Status.WARN);
     expect(selectFrom.verifiableCredential?.length).toEqual(2);
-    expect(selectFrom.matches![0]?.from).toEqual(['A']);
+    expect(selectFrom.matches![0]?.from).toEqual('A');
     expect(selectFrom.matches![0]?.vc_path).toEqual(['$.verifiableCredential[0]']);
-    expect(selectFrom.matches![1]?.from).toEqual(['B']);
+    expect(selectFrom.matches![1]?.from).toEqual('B');
     expect(selectFrom.matches![1]?.vc_path).toEqual(['$.verifiableCredential[1]']);
     const presentationResult = pex.presentationFrom(pdSchema, selectFrom.verifiableCredential as IVerifiableCredential[]);
     const presentation = presentationResult.presentation;
@@ -530,7 +530,7 @@ describe('evaluate JGiter tests', () => {
     const vcs = getVerifiableCredentials();
     const selectResult = pex.selectFrom(pdSchema, vcs);
     expect(selectResult.errors?.length).toEqual(6);
-    expect(selectResult.areRequiredCredentialsPresent).toEqual(Status.ERROR);
+    expect(selectResult.areRequiredCredentialsPresent).toEqual(Status.WARN);
   });
 
   it('Evaluate case with with single submission requirements (A pick min 2)', () => {


### PR DESCRIPTION
- fixing all rule handling:
  - all rule should be applied when there's no SubmissionRequirement object present.
  - if for all rule, there's one credential for more than an InputDescriptor, we're generating WARN and not INFO. previous version was expecting one credential to satisfy all the InputDescriptors. In this version we're expecting each VerifiableCredential to satisfy just one InputDescriptor. In other cases it will result in a WARN
  - better handling the logic and found some edge cases
- fixing pick rule
  - fixed some issues mentioned in #115 and also other issues raised during the tests
- interface change
  - changed the value of `from` in `SubmissionRequirementMatch` to be a singular string. This is to be in line with `PresentationSubmission` object