### PR TITLE
Fix evaluation rule ALL when there are no marked input descriptors

### DIFF
--- a/lib/evaluation/evaluationClientWrapper.ts
+++ b/lib/evaluation/evaluationClientWrapper.ts
@@ -4,7 +4,7 @@ import { IVerifiableCredential, OriginalVerifiableCredential, WrappedVerifiableC
 
 import { Checked, Status } from '../ConstraintUtils';
 import { PresentationSubmissionLocation } from '../signing';
-import { IInternalPresentationDefinition, InternalPresentationDefinitionV2, IPresentationDefinition } from '../types';
+import { IInternalPresentationDefinition, IPresentationDefinition, InternalPresentationDefinitionV2 } from '../types';
 import { JsonPathUtils, ObjectUtils } from '../utils';
 
 import { EvaluationResults, HandlerCheckResult, SelectResults, SubmissionRequirementMatch } from './core';
@@ -478,7 +478,7 @@ export class EvaluationClientWrapper {
       if (sr.from) {
         if (sr.rule === Rules.All) {
           const [count, matched] = this.countMatchingInputDescriptors(sr, marked);
-          if (count !== groupCount.get(sr.from)) {
+          if (count !== (groupCount.get(sr.from) || 0)) {
             throw Error(`Not all input descriptors are members of group ${sr.from}`);
           }
           total++;


### PR DESCRIPTION
- **What kind of change does this PR introduce?**
Bug fix: If there is a submission requirement with a rule all, if no selected credentials can be matched against the requirements defined, the "Not all input descriptors are members of group" will be triggered, masking any error behind.

For instance, this error is triggered even if there are no input descriptors in the Presentation definition with the group belonging to the rule All, and the expected count of them is 0. 

- **What is the current behavior?** (You can also link to an open issue here)
An error with "Not all input descriptors are members of group" will be triggered.

- **What is the new behavior (if this is a feature change)?**
The "Not all input descriptors are members of group" error will be triggered only if there should be matching ids satisfied.

- **Other information**:
The issue comes because `groupCount.get(sr.from)` can be (and actually is) undefined if no input descriptors are satisfied
