### PR TITLE
chore: update sd-jwt

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,9 @@
   },
   "dependencies": {
     "@astronautlabs/jsonpath": "^1.1.2",
-    "@sd-jwt/core": "^0.1.2-alpha.2",
+    "@sd-jwt/present": "^0.1.2-alpha.9",
+    "@sd-jwt/decode": "^0.1.2-alpha.9",
+    "@sd-jwt/utils": "^0.1.2-alpha.9",
     "@sphereon/pex-models": "^2.1.5",
     "@sphereon/ssi-types": "0.18.0",
     "ajv": "^8.12.0",
@@ -71,11 +73,6 @@
     "ts-json-schema-generator": "^1.5.0",
     "ts-node": "^10.9.2",
     "typescript": "^5.3.3"
-  },
-  "resolutions": {
-    "@sd-jwt/utils": "0.1.2-alpha.2",
-    "@sd-jwt/decode": "0.1.2-alpha.1",
-    "@sd-jwt/types": "0.1.2-alpha.3"
   },
   "files": [
     "index.ts",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@sd-jwt/decode": "^0.2.0",
     "@sd-jwt/utils": "^0.2.0",
     "@sphereon/pex-models": "^2.1.5",
-    "@sphereon/ssi-types": "0.18.0",
+    "@sphereon/ssi-types": "0.18.1",
     "ajv": "^8.12.0",
     "ajv-formats": "^2.1.1",
     "jwt-decode": "^3.1.2",

--- a/package.json
+++ b/package.json
@@ -42,9 +42,9 @@
   },
   "dependencies": {
     "@astronautlabs/jsonpath": "^1.1.2",
-    "@sd-jwt/present": "^0.1.2-alpha.9",
-    "@sd-jwt/decode": "^0.1.2-alpha.9",
-    "@sd-jwt/utils": "^0.1.2-alpha.9",
+    "@sd-jwt/present": "^0.2.0",
+    "@sd-jwt/decode": "^0.2.0",
+    "@sd-jwt/utils": "^0.2.0",
     "@sphereon/pex-models": "^2.1.5",
     "@sphereon/ssi-types": "0.18.0",
     "ajv": "^8.12.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -703,33 +703,33 @@
   dependencies:
     buffer "*"
 
-"@sd-jwt/decode@^0.1.2-alpha.9":
-  version "0.1.2-alpha.9"
-  resolved "https://registry.yarnpkg.com/@sd-jwt/decode/-/decode-0.1.2-alpha.9.tgz#02bb88725ba8e3ca0957624ef3eee7d2e3dc2ef9"
-  integrity sha512-3Hx5yd1b9gDC0wK7ZkNVzKevyvdGGkmV+mK7/LBUIR+q5SLZlwOmIHz80EM+8Eg0WFAnAmRgWKjn7jWWRQO5dw==
+"@sd-jwt/decode@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@sd-jwt/decode/-/decode-0.2.0.tgz#44211418fd0884a160f8223feedfe04ae52398c4"
+  integrity sha512-nmiZN3SQ4ApapEu+rS1h/YAkDIq3exgN7swSCsEkrxSEwnBSbXtISIY/sv+EmwnehF1rcKbivHfHNxOWYtlxvg==
   dependencies:
-    "@sd-jwt/types" "0.1.2-alpha.9"
-    "@sd-jwt/utils" "0.1.2-alpha.9"
+    "@sd-jwt/types" "0.2.0"
+    "@sd-jwt/utils" "0.2.0"
 
-"@sd-jwt/present@^0.1.2-alpha.9":
-  version "0.1.2-alpha.9"
-  resolved "https://registry.yarnpkg.com/@sd-jwt/present/-/present-0.1.2-alpha.9.tgz#f0577dcc66dc08e6bc91faf108565e0fc40d2383"
-  integrity sha512-LR7uIoC4As2EmGke+lCv2GifG2Xmr4iEFacx30GJW1n35T7vRBDpldIuoMNqHmsR+z3eHx/TWtjrXsh7lGcFtw==
+"@sd-jwt/present@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@sd-jwt/present/-/present-0.2.0.tgz#01ecbd09dd21287be892b36d754a79c8629387f2"
+  integrity sha512-6xDBiB+UqCwW8k7O7OUJ7BgC/8zcO+AD5ZX1k4I6yjDM9vscgPulSVxT/yUH+Aov3cZ/BKvfKC0qDEZkHmP/kg==
   dependencies:
-    "@sd-jwt/types" "0.1.2-alpha.9"
-    "@sd-jwt/utils" "0.1.2-alpha.9"
+    "@sd-jwt/types" "0.2.0"
+    "@sd-jwt/utils" "0.2.0"
 
-"@sd-jwt/types@0.1.2-alpha.9":
-  version "0.1.2-alpha.9"
-  resolved "https://registry.yarnpkg.com/@sd-jwt/types/-/types-0.1.2-alpha.9.tgz#198899e3a98f9329f35b20fd8af5c1ee37e1e739"
-  integrity sha512-j7Nf3RhQshkEjf3RQhF5hWMMOPQmzwhXBUhjcOoF5eJNgkpF6R13ryb3GDJHkRomIhkygaWaFEzC+ioRAZ7FzQ==
+"@sd-jwt/types@0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@sd-jwt/types/-/types-0.2.0.tgz#3cb50392e1b76ce69453f403c71c937a6e202352"
+  integrity sha512-16WFRcL/maG0/JxN9UCSx07/vJ2SDbGscv9gDLmFLgJzhJcGPer41XfI6aDfVARYP430wHFixChfY/n7qC1L/Q==
 
-"@sd-jwt/utils@0.1.2-alpha.9", "@sd-jwt/utils@^0.1.2-alpha.9":
-  version "0.1.2-alpha.9"
-  resolved "https://registry.yarnpkg.com/@sd-jwt/utils/-/utils-0.1.2-alpha.9.tgz#efbde280798afb964e829726214167f50e7022a3"
-  integrity sha512-oPNWO/XDUkJxdEyOZvmLoqCo0uwiu5Xk0wGkmpwB9KtzeaioVW3JziFUswEczE9RED4+dOWtQwbSpEcy1DEWQw==
+"@sd-jwt/utils@0.2.0", "@sd-jwt/utils@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@sd-jwt/utils/-/utils-0.2.0.tgz#ef52b744116e874f72ec01978f0631ad5a131eb7"
+  integrity sha512-oHCfRYVHCb5RNwdq3eHAt7P9d7TsEaSM1TTux+xl1I9PeQGLtZETnto9Gchtzn8FlTrMdVsLlcuAcK6Viwj1Qw==
   dependencies:
-    "@sd-jwt/types" "0.1.2-alpha.9"
+    "@sd-jwt/types" "0.2.0"
     buffer "*"
 
 "@sinclair/typebox@^0.27.8":

--- a/yarn.lock
+++ b/yarn.lock
@@ -703,34 +703,33 @@
   dependencies:
     buffer "*"
 
-"@sd-jwt/core@^0.1.2-alpha.2":
-  version "0.1.2-alpha.2"
-  resolved "https://registry.yarnpkg.com/@sd-jwt/core/-/core-0.1.2-alpha.2.tgz#572680c388f8c9d0922b849ac87b43c5c88e2672"
-  integrity sha512-MNBzv3TtBRwnlYoCrzS0tMcQIdesiN4H3XbCYbZr7Ku0lLbBJtWR2hp6xEyC3VQPlphC6XCUNOvNoRhDsVgVmg==
+"@sd-jwt/decode@^0.1.2-alpha.9":
+  version "0.1.2-alpha.9"
+  resolved "https://registry.yarnpkg.com/@sd-jwt/decode/-/decode-0.1.2-alpha.9.tgz#02bb88725ba8e3ca0957624ef3eee7d2e3dc2ef9"
+  integrity sha512-3Hx5yd1b9gDC0wK7ZkNVzKevyvdGGkmV+mK7/LBUIR+q5SLZlwOmIHz80EM+8Eg0WFAnAmRgWKjn7jWWRQO5dw==
   dependencies:
-    "@sd-jwt/decode" "workspace:*"
-    "@sd-jwt/types" "workspace:*"
-    "@sd-jwt/utils" "workspace:*"
+    "@sd-jwt/types" "0.1.2-alpha.9"
+    "@sd-jwt/utils" "0.1.2-alpha.9"
 
-"@sd-jwt/decode@0.1.2-alpha.1", "@sd-jwt/decode@workspace:*":
-  version "0.1.2-alpha.1"
-  resolved "https://registry.yarnpkg.com/@sd-jwt/decode/-/decode-0.1.2-alpha.1.tgz#163c6bf4f0702c6d310ccc3f3f3c726863d8c30e"
-  integrity sha512-gm6iQeNVZFErk2yvhsK1Q48koGbJPGh6yFDEd9ACdprOkzHI/TAz9ytJbxmHk4wTmpy1MBxnKuljzaSGOcQXEw==
+"@sd-jwt/present@^0.1.2-alpha.9":
+  version "0.1.2-alpha.9"
+  resolved "https://registry.yarnpkg.com/@sd-jwt/present/-/present-0.1.2-alpha.9.tgz#f0577dcc66dc08e6bc91faf108565e0fc40d2383"
+  integrity sha512-LR7uIoC4As2EmGke+lCv2GifG2Xmr4iEFacx30GJW1n35T7vRBDpldIuoMNqHmsR+z3eHx/TWtjrXsh7lGcFtw==
   dependencies:
-    "@sd-jwt/types" "workspace:*"
-    "@sd-jwt/utils" "workspace:*"
+    "@sd-jwt/types" "0.1.2-alpha.9"
+    "@sd-jwt/utils" "0.1.2-alpha.9"
 
-"@sd-jwt/types@0.1.2-alpha.3", "@sd-jwt/types@workspace:*":
-  version "0.1.2-alpha.3"
-  resolved "https://registry.yarnpkg.com/@sd-jwt/types/-/types-0.1.2-alpha.3.tgz#5e42ceb18a6b6e3cb9cdc9607a2c3d27d7ab12df"
-  integrity sha512-xeP2Z+Ub8nsdbuT2JqQDYs93C1TTNm9efZI8+rAxlyeUuCl2sbJnWiUR39kU6jlYKYs1U7c31wMf8aP4yMMUdg==
+"@sd-jwt/types@0.1.2-alpha.9":
+  version "0.1.2-alpha.9"
+  resolved "https://registry.yarnpkg.com/@sd-jwt/types/-/types-0.1.2-alpha.9.tgz#198899e3a98f9329f35b20fd8af5c1ee37e1e739"
+  integrity sha512-j7Nf3RhQshkEjf3RQhF5hWMMOPQmzwhXBUhjcOoF5eJNgkpF6R13ryb3GDJHkRomIhkygaWaFEzC+ioRAZ7FzQ==
 
-"@sd-jwt/utils@0.1.2-alpha.2", "@sd-jwt/utils@workspace:*":
-  version "0.1.2-alpha.2"
-  resolved "https://registry.yarnpkg.com/@sd-jwt/utils/-/utils-0.1.2-alpha.2.tgz#df94cc675bb0a43df44f327ec5142260ccf49add"
-  integrity sha512-jl6Tk7agFdi9Ebeg3S3HdI7wl0uvelknSKM/X5DGx6a5EomJyx40dOc+KKeNf22me+8l8QJ7a0JyNkD/RP3KQQ==
+"@sd-jwt/utils@0.1.2-alpha.9", "@sd-jwt/utils@^0.1.2-alpha.9":
+  version "0.1.2-alpha.9"
+  resolved "https://registry.yarnpkg.com/@sd-jwt/utils/-/utils-0.1.2-alpha.9.tgz#efbde280798afb964e829726214167f50e7022a3"
+  integrity sha512-oPNWO/XDUkJxdEyOZvmLoqCo0uwiu5Xk0wGkmpwB9KtzeaioVW3JziFUswEczE9RED4+dOWtQwbSpEcy1DEWQw==
   dependencies:
-    "@sd-jwt/types" "workspace:*"
+    "@sd-jwt/types" "0.1.2-alpha.9"
     buffer "*"
 
 "@sinclair/typebox@^0.27.8":

--- a/yarn.lock
+++ b/yarn.lock
@@ -696,13 +696,6 @@
   resolved "https://registry.yarnpkg.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz#a77ea742fab25775145434eb1d2328cf5013ac33"
   integrity sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==
 
-"@sd-jwt/core@0.1.2-alpha.0":
-  version "0.1.2-alpha.0"
-  resolved "https://registry.yarnpkg.com/@sd-jwt/core/-/core-0.1.2-alpha.0.tgz#a1b6ed2c7efc6d71d8fcd063b6624cf77c1eb21f"
-  integrity sha512-x4MVXar6WmPauZDRJ3aHwaY8o/bHzN77Ts7o43JKuuqIBFjPgAcSlRtd/Xk1rWhazFai4MCIwJDSQ1OQRJtNug==
-  dependencies:
-    buffer "*"
-
 "@sd-jwt/decode@^0.2.0":
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@sd-jwt/decode/-/decode-0.2.0.tgz#44211418fd0884a160f8223feedfe04ae52398c4"
@@ -756,12 +749,12 @@
   resolved "https://registry.yarnpkg.com/@sphereon/pex-models/-/pex-models-2.1.5.tgz#ba4474a3783081392b72403c4c8ee6da3d2e5585"
   integrity sha512-7THexvdYUK/Dh8olBB46ErT9q/RnecnMdb5r2iwZ6be0Dt4vQLAUN7QU80H0HZBok4jRTb8ydt12x0raBSTHOg==
 
-"@sphereon/ssi-types@0.18.0":
-  version "0.18.0"
-  resolved "https://registry.yarnpkg.com/@sphereon/ssi-types/-/ssi-types-0.18.0.tgz#b4f3a4a9e4e5b28719ce729b679d71d9d220cc26"
-  integrity sha512-D2n42NAhHCwpL4K7BqQXO9dYQ8n3st/1eJQrLqokJ18B9r2gury3km4cp+ZdiIxfefUaP9RBCeuWaiRUvjZ94w==
+"@sphereon/ssi-types@0.18.1":
+  version "0.18.1"
+  resolved "https://registry.yarnpkg.com/@sphereon/ssi-types/-/ssi-types-0.18.1.tgz#c00e4939149f4e441fae56af860735886a4c33a5"
+  integrity sha512-uM0gb1woyc0R+p+qh8tVDi15ZWmpzo9BP0iBp/yRkJar7gAfgwox/yvtEToaH9jROKnDCwL3DDQCDeNucpMkwg==
   dependencies:
-    "@sd-jwt/core" "0.1.2-alpha.0"
+    "@sd-jwt/decode" "^0.2.0"
     jwt-decode "^3.1.2"
 
 "@tokenizer/token@^0.3.0":


### PR DESCRIPTION
Updates sd-jwt to the new structure with subpackages. It also removes the resolutions and updates to newer version of SD-JWT. There are some issues currently with the versions of SD-JWT when you try to install 3.0.0.

Waiting for stable release of sd-jwt, but then it would be great if we can get a ssi-types 18.0.1 and PEX 3.0.1