### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@sd-jwt/present": "^0.6.1",
     "@sd-jwt/types": "^0.6.1",
     "@sphereon/pex-models": "^2.2.2",
-    "@sphereon/ssi-types": "0.19.0",
+    "@sphereon/ssi-types": "0.22.0",
     "ajv": "^8.12.0",
     "ajv-formats": "^2.1.1",
     "jwt-decode": "^3.1.2",


### PR DESCRIPTION
Update ssi-types lib to include the latest sd-jwt packages. Right now it is using the old sd-jwt with v. 0.2 that will fail when creating the ´createAuthorizationResponse`. the older version of sd-jwt requires the aud value that is not required.

After patching to version 0.22.0 the error goes away since this ssi-types version is using the latest sd-jwt packages.