### PR TITLE
chore: update to sd_hash

### DIFF
--- a/lib/PEX.ts
+++ b/lib/PEX.ts
@@ -309,7 +309,7 @@ export class PEX {
         // aud MUST be set by the signer or provided by e.g. SIOP/OpenID4VP lib
         payload: {
           iat: new Date().getTime(),
-          _sd_hash: sdHash,
+          sd_hash: sdHash,
         },
       } satisfies SdJwtKbJwtInput;
 
@@ -495,7 +495,7 @@ export class PEX {
         payload: {
           iat: new Date().getTime(),
           nonce: proofOptions?.nonce,
-          _sd_hash: sdHash,
+          sd_hash: sdHash,
         },
       } satisfies SdJwtKbJwtInput;
 

--- a/lib/signing/types.ts
+++ b/lib/signing/types.ts
@@ -90,7 +90,7 @@ export interface SdJwtKbJwtInput {
   };
   payload: {
     iat: number;
-    _sd_hash: string;
+    sd_hash: string;
     nonce?: string;
   };
 }

--- a/test/SdJwt.spec.ts
+++ b/test/SdJwt.spec.ts
@@ -223,7 +223,7 @@ describe('evaluate', () => {
         payload: {
           iat: expect.any(Number),
           nonce: undefined,
-          _sd_hash: calculateSdHash(decodedSdJwtVcWithDisclosuresRemoved.compactSdJwtVc, 'sha-256', hasher),
+          sd_hash: calculateSdHash(decodedSdJwtVcWithDisclosuresRemoved.compactSdJwtVc, 'sha-256', hasher),
         },
       },
     });


### PR DESCRIPTION
Updates from `_sd_hash` to `sd_hash`.

Breaking change

Fixes #152 