### PR TITLE
feat: add id and type to match interface

### DIFF
--- a/lib/evaluation/core/submissionRequirementMatch.ts
+++ b/lib/evaluation/core/submissionRequirementMatch.ts
@@ -1,6 +1,32 @@
 import { Rules } from '@sphereon/pex-models';
 
+export enum SubmissionRequirementMatchType {
+  /**
+  * Match for a submission_requirements entry in the presentation definition. If the match type
+  * is `SubmissionRequirement` the {@link SubmissionRequirementMatch.id} property refers to the index
+  * of the `submission_requirements` entry in the presentation definition.
+  * 
+  * If the match is a nested match result, this match type refers to the nested index. E.g. a presentation
+  * definition has three `submission_requirements` entries where the second submission requirement (index 1)
+  * has two `from_nested` `submission_requirements` entries and this match referes to the second (index 1) of
+  * this from nested, the {@link SubmissionRequirementMatch.id} property of the outer match refers to the outer index
+  * in the `submission_requirements` entries, and the nested {@link SubmissionRequirementMatch.id} referes to index of the
+  * `from_nested` entries. This can go multiple layers deep.
+  */
+  SubmissionRequirement = 'SubmissionRequirement',
+
+  /**
+   * Match for an input_descriptors entry in the presentation definition. This type will be used
+   * if no submission_requirements are present in the presentation definition. If the match type
+   * is `InputDescriptor` the {@link SubmissionRequirementMatch.id} property referes to the `id`
+   * of the `input_descriptors` entry in the presentation definition.
+   */
+  InputDescriptor = 'InputDescriptor'
+}
+
 export interface SubmissionRequirementMatch {
+  type: SubmissionRequirementMatchType
+  id: string | number
   name?: string;
   rule: Rules;
   min?: number;

--- a/lib/evaluation/core/submissionRequirementMatch.ts
+++ b/lib/evaluation/core/submissionRequirementMatch.ts
@@ -8,7 +8,7 @@ export enum SubmissionRequirementMatchType {
    *
    * If the match is a nested match result, this match type refers to the nested index. E.g. a presentation
    * definition has three `submission_requirements` entries where the second submission requirement (index 1)
-   * has two `from_nested` `submission_requirements` entries and this match referes to the second (index 1) of
+   * has two `from_nested` `submission_requirements` entries and this match refers to the second (index 1) of
    * this from nested, the {@link SubmissionRequirementMatch.id} property of the outer match refers to the outer index
    * in the `submission_requirements` entries, and the nested {@link SubmissionRequirementMatch.id} refers to index of the
    * `from_nested` entries. This can go multiple layers deep.

--- a/lib/evaluation/core/submissionRequirementMatch.ts
+++ b/lib/evaluation/core/submissionRequirementMatch.ts
@@ -18,7 +18,7 @@ export enum SubmissionRequirementMatchType {
   /**
    * Match for an input_descriptors entry in the presentation definition. This type will be used
    * if no submission_requirements are present in the presentation definition. If the match type
-   * is `InputDescriptor` the {@link SubmissionRequirementMatch.id} property referes to the `id`
+   * is `InputDescriptor` the {@link SubmissionRequirementMatch.id} property refers to the `id`
    * of the `input_descriptors` entry in the presentation definition.
    */
   InputDescriptor = 'InputDescriptor',

--- a/lib/evaluation/core/submissionRequirementMatch.ts
+++ b/lib/evaluation/core/submissionRequirementMatch.ts
@@ -2,17 +2,17 @@ import { Rules } from '@sphereon/pex-models';
 
 export enum SubmissionRequirementMatchType {
   /**
-  * Match for a submission_requirements entry in the presentation definition. If the match type
-  * is `SubmissionRequirement` the {@link SubmissionRequirementMatch.id} property refers to the index
-  * of the `submission_requirements` entry in the presentation definition.
-  * 
-  * If the match is a nested match result, this match type refers to the nested index. E.g. a presentation
-  * definition has three `submission_requirements` entries where the second submission requirement (index 1)
-  * has two `from_nested` `submission_requirements` entries and this match referes to the second (index 1) of
-  * this from nested, the {@link SubmissionRequirementMatch.id} property of the outer match refers to the outer index
-  * in the `submission_requirements` entries, and the nested {@link SubmissionRequirementMatch.id} referes to index of the
-  * `from_nested` entries. This can go multiple layers deep.
-  */
+   * Match for a submission_requirements entry in the presentation definition. If the match type
+   * is `SubmissionRequirement` the {@link SubmissionRequirementMatch.id} property refers to the index
+   * of the `submission_requirements` entry in the presentation definition.
+   *
+   * If the match is a nested match result, this match type refers to the nested index. E.g. a presentation
+   * definition has three `submission_requirements` entries where the second submission requirement (index 1)
+   * has two `from_nested` `submission_requirements` entries and this match referes to the second (index 1) of
+   * this from nested, the {@link SubmissionRequirementMatch.id} property of the outer match refers to the outer index
+   * in the `submission_requirements` entries, and the nested {@link SubmissionRequirementMatch.id} referes to index of the
+   * `from_nested` entries. This can go multiple layers deep.
+   */
   SubmissionRequirement = 'SubmissionRequirement',
 
   /**
@@ -21,12 +21,12 @@ export enum SubmissionRequirementMatchType {
    * is `InputDescriptor` the {@link SubmissionRequirementMatch.id} property referes to the `id`
    * of the `input_descriptors` entry in the presentation definition.
    */
-  InputDescriptor = 'InputDescriptor'
+  InputDescriptor = 'InputDescriptor',
 }
 
 export interface SubmissionRequirementMatch {
-  type: SubmissionRequirementMatchType
-  id: string | number
+  type: SubmissionRequirementMatchType;
+  id: string | number;
   name?: string;
   rule: Rules;
   min?: number;

--- a/lib/evaluation/core/submissionRequirementMatch.ts
+++ b/lib/evaluation/core/submissionRequirementMatch.ts
@@ -10,7 +10,7 @@ export enum SubmissionRequirementMatchType {
    * definition has three `submission_requirements` entries where the second submission requirement (index 1)
    * has two `from_nested` `submission_requirements` entries and this match referes to the second (index 1) of
    * this from nested, the {@link SubmissionRequirementMatch.id} property of the outer match refers to the outer index
-   * in the `submission_requirements` entries, and the nested {@link SubmissionRequirementMatch.id} referes to index of the
+   * in the `submission_requirements` entries, and the nested {@link SubmissionRequirementMatch.id} refers to index of the
    * `from_nested` entries. This can go multiple layers deep.
    */
   SubmissionRequirement = 'SubmissionRequirement',

--- a/lib/evaluation/evaluationClientWrapper.ts
+++ b/lib/evaluation/evaluationClientWrapper.ts
@@ -22,7 +22,14 @@ import {
 import { JsonPathUtils, ObjectUtils } from '../utils';
 import { getVpFormatForVcFormat } from '../utils/formatMap';
 
-import { EvaluationResults, HandlerCheckResult, PresentationEvaluationResults, SelectResults, SubmissionRequirementMatch, SubmissionRequirementMatchType } from './core';
+import {
+  EvaluationResults,
+  HandlerCheckResult,
+  PresentationEvaluationResults,
+  SelectResults,
+  SubmissionRequirementMatch,
+  SubmissionRequirementMatchType,
+} from './core';
 import { EvaluationClient } from './evaluationClient';
 
 interface SubmissionSatisfiesSubmissionRequirementResult {
@@ -260,7 +267,7 @@ export class EvaluationClientWrapper {
 
         name: sr.name,
         type: SubmissionRequirementMatchType.SubmissionRequirement,
-        id: Number(srIndex)
+        id: Number(srIndex),
       };
 
       if (sr.from) {
@@ -301,14 +308,14 @@ export class EvaluationClientWrapper {
       for (const vcPath of sameIdVcs) {
         const inputDescriptorResults = JsonPathUtils.extractInputField<InputDescriptorV1 | InputDescriptorV2>(pd, [idPath]);
         if (inputDescriptorResults.length) {
-          const inputDescriptor = inputDescriptorResults[0].value
+          const inputDescriptor = inputDescriptorResults[0].value;
           submissionRequirementMatches.push({
             name: inputDescriptor.name || inputDescriptor.id,
             rule: Rules.All,
             vc_path: [vcPath],
 
             type: SubmissionRequirementMatchType.InputDescriptor,
-            id: inputDescriptor.id
+            id: inputDescriptor.id,
           });
         }
       }
@@ -321,9 +328,9 @@ export class EvaluationClientWrapper {
     sr: SubmissionRequirement,
     marked: HandlerCheckResult[],
   ): string[] {
-    const vcPaths = new Set<string>()
+    const vcPaths = new Set<string>();
 
-    if (!sr.from) return Array.from(vcPaths)
+    if (!sr.from) return Array.from(vcPaths);
 
     for (const m of marked) {
       const inputDescriptor: InputDescriptorV2 = jp.query(pd, m.input_descriptor_path)[0];
@@ -335,7 +342,7 @@ export class EvaluationClientWrapper {
       }
     }
 
-    return Array.from(vcPaths)
+    return Array.from(vcPaths);
   }
 
   public evaluate(

--- a/lib/evaluation/evaluationClientWrapper.ts
+++ b/lib/evaluation/evaluationClientWrapper.ts
@@ -279,7 +279,7 @@ export class EvaluationClientWrapper {
       sr.count ? (srm.count = sr.count) : undefined;
 
       if (sr.from) {
-        const matchingVcPaths = this.getMatchingVcPatchsForSubmissionRequirement(pd, sr, marked);
+        const matchingVcPaths = this.getMatchingVcPathsForSubmissionRequirement(pd, sr, marked);
         srm.vc_path.push(...matchingVcPaths);
         submissionRequirementMatches.push(srm);
       } else if (sr.from_nested) {
@@ -323,7 +323,7 @@ export class EvaluationClientWrapper {
     return this.removeDuplicateSubmissionRequirementMatches(submissionRequirementMatches);
   }
 
-  private getMatchingVcPatchsForSubmissionRequirement(
+  private getMatchingVcPathsForSubmissionRequirement(
     pd: IInternalPresentationDefinition,
     sr: SubmissionRequirement,
     marked: HandlerCheckResult[],

--- a/lib/evaluation/evaluationClientWrapper.ts
+++ b/lib/evaluation/evaluationClientWrapper.ts
@@ -22,7 +22,7 @@ import {
 import { JsonPathUtils, ObjectUtils } from '../utils';
 import { getVpFormatForVcFormat } from '../utils/formatMap';
 
-import { EvaluationResults, HandlerCheckResult, PresentationEvaluationResults, SelectResults, SubmissionRequirementMatch } from './core';
+import { EvaluationResults, HandlerCheckResult, PresentationEvaluationResults, SelectResults, SubmissionRequirementMatch, SubmissionRequirementMatchType } from './core';
 import { EvaluationClient } from './evaluationClient';
 
 interface SubmissionSatisfiesSubmissionRequirementResult {
@@ -252,13 +252,17 @@ export class EvaluationClientWrapper {
     marked: HandlerCheckResult[],
   ): SubmissionRequirementMatch[] {
     const submissionRequirementMatches: SubmissionRequirementMatch[] = [];
-    for (const sr of submissionRequirements) {
+    for (const [srIndex, sr] of Object.entries(submissionRequirements)) {
       // Create a default SubmissionRequirementMatch object
       const srm: SubmissionRequirementMatch = {
-        name: pd.name || pd.id,
         rule: sr.rule,
         vc_path: [],
+
+        name: sr.name,
+        type: SubmissionRequirementMatchType.SubmissionRequirement,
+        id: Number(srIndex)
       };
+
       if (sr.from) {
         srm.from = sr.from;
       }
@@ -268,12 +272,9 @@ export class EvaluationClientWrapper {
       sr.count ? (srm.count = sr.count) : undefined;
 
       if (sr.from) {
-        const matchingDescriptors = this.mapMatchingDescriptors(pd, sr, marked);
-        if (matchingDescriptors) {
-          srm.vc_path.push(...matchingDescriptors.vc_path);
-          srm.name = matchingDescriptors.name;
-          submissionRequirementMatches.push(srm);
-        }
+        const matchingVcPaths = this.getMatchingVcPatchsForSubmissionRequirement(pd, sr, marked);
+        srm.vc_path.push(...matchingVcPaths);
+        submissionRequirementMatches.push(srm);
       } else if (sr.from_nested) {
         // Recursive call to matchSubmissionRequirements for nested requirements
         try {
@@ -298,12 +299,16 @@ export class EvaluationClientWrapper {
         continue;
       }
       for (const vcPath of sameIdVcs) {
-        const idRes = JsonPathUtils.extractInputField(pd, [idPath]);
-        if (idRes.length) {
+        const inputDescriptorResults = JsonPathUtils.extractInputField<InputDescriptorV1 | InputDescriptorV2>(pd, [idPath]);
+        if (inputDescriptorResults.length) {
+          const inputDescriptor = inputDescriptorResults[0].value
           submissionRequirementMatches.push({
-            name: (idRes[0].value as InputDescriptorV1 | InputDescriptorV2).name || (idRes[0].value as InputDescriptorV1 | InputDescriptorV2).id,
+            name: inputDescriptor.name || inputDescriptor.id,
             rule: Rules.All,
             vc_path: [vcPath],
+
+            type: SubmissionRequirementMatchType.InputDescriptor,
+            id: inputDescriptor.id
           });
         }
       }
@@ -311,29 +316,26 @@ export class EvaluationClientWrapper {
     return this.removeDuplicateSubmissionRequirementMatches(submissionRequirementMatches);
   }
 
-  private mapMatchingDescriptors(
+  private getMatchingVcPatchsForSubmissionRequirement(
     pd: IInternalPresentationDefinition,
     sr: SubmissionRequirement,
     marked: HandlerCheckResult[],
-  ): SubmissionRequirementMatch {
-    const srm: Partial<SubmissionRequirementMatch> = { rule: sr.rule, vc_path: [] };
-    if (sr?.from) {
-      srm.from = sr.from;
-      // updating the srm.name everytime and since we have only one, we're sending the last one
-      for (const m of marked) {
-        const inDesc: InputDescriptorV2 = jp.query(pd, m.input_descriptor_path)[0];
-        if (inDesc.group && inDesc.group.indexOf(sr.from) === -1) {
-          continue;
-        }
-        srm.name = inDesc.name || inDesc.id;
-        if (m.payload.group.includes(sr.from)) {
-          if (srm.vc_path?.indexOf(m.verifiable_credential_path) === -1) {
-            srm.vc_path.push(m.verifiable_credential_path);
-          }
-        }
+  ): string[] {
+    const vcPaths = new Set<string>()
+
+    if (!sr.from) return Array.from(vcPaths)
+
+    for (const m of marked) {
+      const inputDescriptor: InputDescriptorV2 = jp.query(pd, m.input_descriptor_path)[0];
+      if (inputDescriptor.group && inputDescriptor.group.indexOf(sr.from) === -1) {
+        continue;
+      }
+      if (m.payload.group.includes(sr.from)) {
+        vcPaths.add(m.verifiable_credential_path);
       }
     }
-    return srm as SubmissionRequirementMatch;
+
+    return Array.from(vcPaths)
   }
 
   public evaluate(

--- a/lib/utils/jsonPathUtils.ts
+++ b/lib/utils/jsonPathUtils.ts
@@ -48,7 +48,7 @@ export class JsonPathUtils {
       }
    result: [ { value: 19, path: [ '$', 'details', 'information', 0, 'age' ] } ]
    */
-  public static extractInputField(obj: InputFieldType, paths: string[]): { value: unknown; path: PathComponent[] }[] {
+  public static extractInputField<PathValue extends unknown = unknown>(obj: InputFieldType, paths: string[]): { value: PathValue; path: PathComponent[] }[] {
     let result: { value: unknown; path: PathComponent[] }[] = [];
     if (paths) {
       for (const path of paths) {
@@ -58,7 +58,7 @@ export class JsonPathUtils {
         }
       }
     }
-    return result;
+    return result as { value: PathValue; path: PathComponent[] }[];
   }
 
   public static changePropertyNameRecursively(

--- a/lib/utils/jsonPathUtils.ts
+++ b/lib/utils/jsonPathUtils.ts
@@ -48,7 +48,7 @@ export class JsonPathUtils {
       }
    result: [ { value: 19, path: [ '$', 'details', 'information', 0, 'age' ] } ]
    */
-  public static extractInputField<PathValue extends unknown = unknown>(obj: InputFieldType, paths: string[]): { value: PathValue; path: PathComponent[] }[] {
+  public static extractInputField<PathValue = unknown>(obj: InputFieldType, paths: string[]): { value: PathValue; path: PathComponent[] }[] {
     let result: { value: unknown; path: PathComponent[] }[] = [];
     if (paths) {
       for (const path of paths) {

--- a/test/PEX.spec.ts
+++ b/test/PEX.spec.ts
@@ -944,7 +944,8 @@ describe('evaluate', () => {
     const jwtVc: IVerifiableCredential = getFileAsJson('test/dif_pe_examples/vp/vp_general.json').verifiableCredential[0];
     jwtVc['iss' as keyof IVerifiableCredential] = 'did:test:456';
     expect(() => SSITypesBuilder.mapExternalVerifiableCredentialsToWrappedVcs([jwtVc])).toThrowError(
-      `Inconsistent issuers between JWT claim (${jwtVc['iss' as keyof IVerifiableCredential]}) and VC value (${(<ICredential>jwtVc['vc' as keyof IVerifiableCredential]).issuer
+      `Inconsistent issuers between JWT claim (${jwtVc['iss' as keyof IVerifiableCredential]}) and VC value (${
+        (<ICredential>jwtVc['vc' as keyof IVerifiableCredential]).issuer
       })`,
     );
   });
@@ -965,7 +966,8 @@ describe('evaluate', () => {
     jwtVc['nbf' as keyof IVerifiableCredential] = nbf / 1000;
     (<ICredential>jwtVc['vc' as keyof IVerifiableCredential]).issuanceDate = new Date(+new Date() + 2000).toISOString();
     expect(() => SSITypesBuilder.mapExternalVerifiableCredentialsToWrappedVcs([jwtVc])).toThrowError(
-      `Inconsistent issuance dates between JWT claim (${new Date(nbf).toISOString().replace(/\.\d\d\dZ/, 'Z')}) and VC value (${(<ICredential>jwtVc['vc' as keyof IVerifiableCredential]).issuanceDate
+      `Inconsistent issuance dates between JWT claim (${new Date(nbf).toISOString().replace(/\.\d\d\dZ/, 'Z')}) and VC value (${
+        (<ICredential>jwtVc['vc' as keyof IVerifiableCredential]).issuanceDate
       })`,
     );
   });
@@ -983,7 +985,8 @@ describe('evaluate', () => {
     const jwtVc: IVerifiableCredential = getFileAsJson('test/dif_pe_examples/vp/vp_general.json').verifiableCredential[0];
     jwtVc['sub' as keyof IVerifiableCredential] = 'did:test:123';
     expect(() => SSITypesBuilder.mapExternalVerifiableCredentialsToWrappedVcs([jwtVc])).toThrowError(
-      `Inconsistent credential subject ids between JWT claim (${jwtVc['sub' as keyof IVerifiableCredential]}) and VC value (${((<ICredential>jwtVc['vc' as keyof IVerifiableCredential]).credentialSubject as ICredentialSubject).id
+      `Inconsistent credential subject ids between JWT claim (${jwtVc['sub' as keyof IVerifiableCredential]}) and VC value (${
+        ((<ICredential>jwtVc['vc' as keyof IVerifiableCredential]).credentialSubject as ICredentialSubject).id
       })`,
     );
   });
@@ -999,7 +1002,8 @@ describe('evaluate', () => {
     const jwtVc: IVerifiableCredential = getFileAsJson('test/dif_pe_examples/vp/vp_general.json').verifiableCredential[0];
     jwtVc['jti' as keyof IVerifiableCredential] = 'test';
     expect(() => SSITypesBuilder.mapExternalVerifiableCredentialsToWrappedVcs([jwtVc])).toThrowError(
-      `Inconsistent credential ids between JWT claim (${jwtVc['jti' as keyof IVerifiableCredential]}) and VC value (${(<ICredential>jwtVc['vc' as keyof IVerifiableCredential]).id
+      `Inconsistent credential ids between JWT claim (${jwtVc['jti' as keyof IVerifiableCredential]}) and VC value (${
+        (<ICredential>jwtVc['vc' as keyof IVerifiableCredential]).id
       })`,
     );
   });
@@ -1237,7 +1241,7 @@ describe('evaluate', () => {
       'eyJ4NWMiOlsiTUlJQ2REQ0NBaHVnQXdJQkFnSUJBakFLQmdncWhrak9QUVFEQWpDQmlERUxNQWtHQTFVRUJoTUNSRVV4RHpBTkJnTlZCQWNNQmtKbGNteHBiakVkTUJzR0ExVUVDZ3dVUW5WdVpHVnpaSEoxWTJ0bGNtVnBJRWR0WWtneEVUQVBCZ05WQkFzTUNGUWdRMU1nU1VSRk1UWXdOQVlEVlFRRERDMVRVRkpKVGtRZ1JuVnVhMlVnUlZWRVNTQlhZV3hzWlhRZ1VISnZkRzkwZVhCbElFbHpjM1ZwYm1jZ1EwRXdIaGNOTWpRd05UTXhNRGd4TXpFM1doY05NalV3TnpBMU1EZ3hNekUzV2pCc01Rc3dDUVlEVlFRR0V3SkVSVEVkTUJzR0ExVUVDZ3dVUW5WdVpHVnpaSEoxWTJ0bGNtVnBJRWR0WWtneENqQUlCZ05WQkFzTUFVa3hNakF3QmdOVkJBTU1LVk5RVWtsT1JDQkdkVzVyWlNCRlZVUkpJRmRoYkd4bGRDQlFjbTkwYjNSNWNHVWdTWE56ZFdWeU1Ga3dFd1lIS29aSXpqMENBUVlJS29aSXpqMERBUWNEUWdBRU9GQnE0WU1LZzR3NWZUaWZzeXR3QnVKZi83RTdWaFJQWGlObTUyUzNxMUVUSWdCZFh5REsza1Z4R3hnZUhQaXZMUDN1dU12UzZpREVjN3FNeG12ZHVLT0JrRENCalRBZEJnTlZIUTRFRmdRVWlQaENrTEVyRFhQTFcyL0owV1ZlZ2h5dyttSXdEQVlEVlIwVEFRSC9CQUl3QURBT0JnTlZIUThCQWY4RUJBTUNCNEF3TFFZRFZSMFJCQ1l3SklJaVpHVnRieTV3YVdRdGFYTnpkV1Z5TG1KMWJtUmxjMlJ5ZFdOclpYSmxhUzVrWlRBZkJnTlZIU01FR0RBV2dCVFVWaGpBaVRqb0RsaUVHTWwyWXIrcnU4V1F2akFLQmdncWhrak9QUVFEQWdOSEFEQkVBaUFiZjVUemtjUXpoZldvSW95aTFWTjdkOEk5QnNGS20xTVdsdVJwaDJieUdRSWdLWWtkck5mMnhYUGpWU2JqVy9VLzVTNXZBRUM1WHhjT2FudXNPQnJvQmJVPSIsIk1JSUNlVENDQWlDZ0F3SUJBZ0lVQjVFOVFWWnRtVVljRHRDaktCL0gzVlF2NzJnd0NnWUlLb1pJemowRUF3SXdnWWd4Q3pBSkJnTlZCQVlUQWtSRk1ROHdEUVlEVlFRSERBWkNaWEpzYVc0eEhUQWJCZ05WQkFvTUZFSjFibVJsYzJSeWRXTnJaWEpsYVNCSGJXSklNUkV3RHdZRFZRUUxEQWhVSUVOVElFbEVSVEUyTURRR0ExVUVBd3d0VTFCU1NVNUVJRVoxYm10bElFVlZSRWtnVjJGc2JHVjBJRkJ5YjNSdmRIbHdaU0JKYzNOMWFXNW5JRU5CTUI0WERUSTBNRFV6TVRBMk5EZ3dPVm9YRFRNME1EVXlPVEEyTkRnd09Wb3dnWWd4Q3pBSkJnTlZCQVlUQWtSRk1ROHdEUVlEVlFRSERBWkNaWEpzYVc0eEhUQWJCZ05WQkFvTUZFSjFibVJsYzJSeWRXTnJaWEpsYVNCSGJXSklNUkV3RHdZRFZRUUxEQWhVSUVOVElFbEVSVEUyTURRR0ExVUVBd3d0VTFCU1NVNUVJRVoxYm10bElFVlZSRWtnVjJGc2JHVjBJRkJ5YjNSdmRIbHdaU0JKYzNOMWFXNW5JRU5CTUZrd0V3WUhLb1pJemowQ0FRWUlLb1pJemowREFRY0RRZ0FFWUd6ZHdGRG5jNytLbjVpYkF2Q09NOGtlNzdWUXhxZk1jd1pMOElhSUErV0NST2NDZm1ZL2dpSDkycU1ydTVwL2t5T2l2RTBSQy9JYmRNT052RG9VeWFObU1HUXdIUVlEVlIwT0JCWUVGTlJXR01DSk9PZ09XSVFZeVhaaXY2dTd4WkMrTUI4R0ExVWRJd1FZTUJhQUZOUldHTUNKT09nT1dJUVl5WFppdjZ1N3haQytNQklHQTFVZEV3RUIvd1FJTUFZQkFmOENBUUF3RGdZRFZSMFBBUUgvQkFRREFnR0dNQW9HQ0NxR1NNNDlCQU1DQTBjQU1FUUNJR0VtN3drWktIdC9hdGI0TWRGblhXNnlybndNVVQydTEzNmdkdGwxMFk2aEFpQnVURnF2Vll0aDFyYnh6Q1AweFdaSG1RSzlrVnl4bjhHUGZYMjdFSXp6c3c9PSJdLCJraWQiOiJNSUdVTUlHT3BJR0xNSUdJTVFzd0NRWURWUVFHRXdKRVJURVBNQTBHQTFVRUJ3d0dRbVZ5YkdsdU1SMHdHd1lEVlFRS0RCUkNkVzVrWlhOa2NuVmphMlZ5WldrZ1IyMWlTREVSTUE4R0ExVUVDd3dJVkNCRFV5QkpSRVV4TmpBMEJnTlZCQU1NTFZOUVVrbE9SQ0JHZFc1clpTQkZWVVJKSUZkaGJHeGxkQ0JRY205MGIzUjVjR1VnU1hOemRXbHVaeUJEUVFJQkFnPT0iLCJ0eXAiOiJ2YytzZC1qd3QiLCJhbGciOiJFUzI1NiJ9.eyJ2Y3QiOiJJRCIsIl9zZF9hbGciOiJzaGEtMjU2IiwiaXNzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbSIsImNuZiI6eyJqd2siOnsia3R5IjoiRUMiLCJjcnYiOiJQLTI1NiIsImtpZCI6IkhOa3V2RDNmMTMzcG9uZGRJcmZYbmZxQ0U4T1VBRzBrcFNKZHlzUFZMUU0iLCJ4IjoiVDVWWHYtUUpmMzhBblhkOTZxcS1qNmZjSVd3NXZjTXpqNUllRWFMQm9qSSIsInkiOiJyandIN0I5RmVXc1VoWURmTWpaeDVCYWFLalVCWWdTbU1vQTM4S3ZIWkRrIn19LCJpYXQiOjE3MjQ4Njg0Mzl9.PxjYlyQJYu5tYIwOu-VPsIBFXB1z-WI7_QSRs8mPWeLlPfJ8POs23vZtrcBD-lXFQm38z4QRG9zw_yKYF0qDLw~',
       'eyJ4NWMiOlsiTUlJQ2REQ0NBaHVnQXdJQkFnSUJBakFLQmdncWhrak9QUVFEQWpDQmlERUxNQWtHQTFVRUJoTUNSRVV4RHpBTkJnTlZCQWNNQmtKbGNteHBiakVkTUJzR0ExVUVDZ3dVUW5WdVpHVnpaSEoxWTJ0bGNtVnBJRWR0WWtneEVUQVBCZ05WQkFzTUNGUWdRMU1nU1VSRk1UWXdOQVlEVlFRRERDMVRVRkpKVGtRZ1JuVnVhMlVnUlZWRVNTQlhZV3hzWlhRZ1VISnZkRzkwZVhCbElFbHpjM1ZwYm1jZ1EwRXdIaGNOTWpRd05UTXhNRGd4TXpFM1doY05NalV3TnpBMU1EZ3hNekUzV2pCc01Rc3dDUVlEVlFRR0V3SkVSVEVkTUJzR0ExVUVDZ3dVUW5WdVpHVnpaSEoxWTJ0bGNtVnBJRWR0WWtneENqQUlCZ05WQkFzTUFVa3hNakF3QmdOVkJBTU1LVk5RVWtsT1JDQkdkVzVyWlNCRlZVUkpJRmRoYkd4bGRDQlFjbTkwYjNSNWNHVWdTWE56ZFdWeU1Ga3dFd1lIS29aSXpqMENBUVlJS29aSXpqMERBUWNEUWdBRU9GQnE0WU1LZzR3NWZUaWZzeXR3QnVKZi83RTdWaFJQWGlObTUyUzNxMUVUSWdCZFh5REsza1Z4R3hnZUhQaXZMUDN1dU12UzZpREVjN3FNeG12ZHVLT0JrRENCalRBZEJnTlZIUTRFRmdRVWlQaENrTEVyRFhQTFcyL0owV1ZlZ2h5dyttSXdEQVlEVlIwVEFRSC9CQUl3QURBT0JnTlZIUThCQWY4RUJBTUNCNEF3TFFZRFZSMFJCQ1l3SklJaVpHVnRieTV3YVdRdGFYTnpkV1Z5TG1KMWJtUmxjMlJ5ZFdOclpYSmxhUzVrWlRBZkJnTlZIU01FR0RBV2dCVFVWaGpBaVRqb0RsaUVHTWwyWXIrcnU4V1F2akFLQmdncWhrak9QUVFEQWdOSEFEQkVBaUFiZjVUemtjUXpoZldvSW95aTFWTjdkOEk5QnNGS20xTVdsdVJwaDJieUdRSWdLWWtkck5mMnhYUGpWU2JqVy9VLzVTNXZBRUM1WHhjT2FudXNPQnJvQmJVPSIsIk1JSUNlVENDQWlDZ0F3SUJBZ0lVQjVFOVFWWnRtVVljRHRDaktCL0gzVlF2NzJnd0NnWUlLb1pJemowRUF3SXdnWWd4Q3pBSkJnTlZCQVlUQWtSRk1ROHdEUVlEVlFRSERBWkNaWEpzYVc0eEhUQWJCZ05WQkFvTUZFSjFibVJsYzJSeWRXTnJaWEpsYVNCSGJXSklNUkV3RHdZRFZRUUxEQWhVSUVOVElFbEVSVEUyTURRR0ExVUVBd3d0VTFCU1NVNUVJRVoxYm10bElFVlZSRWtnVjJGc2JHVjBJRkJ5YjNSdmRIbHdaU0JKYzNOMWFXNW5JRU5CTUI0WERUSTBNRFV6TVRBMk5EZ3dPVm9YRFRNME1EVXlPVEEyTkRnd09Wb3dnWWd4Q3pBSkJnTlZCQVlUQWtSRk1ROHdEUVlEVlFRSERBWkNaWEpzYVc0eEhUQWJCZ05WQkFvTUZFSjFibVJsYzJSeWRXTnJaWEpsYVNCSGJXSklNUkV3RHdZRFZRUUxEQWhVSUVOVElFbEVSVEUyTURRR0ExVUVBd3d0VTFCU1NVNUVJRVoxYm10bElFVlZSRWtnVjJGc2JHVjBJRkJ5YjNSdmRIbHdaU0JKYzNOMWFXNW5JRU5CTUZrd0V3WUhLb1pJemowQ0FRWUlLb1pJemowREFRY0RRZ0FFWUd6ZHdGRG5jNytLbjVpYkF2Q09NOGtlNzdWUXhxZk1jd1pMOElhSUErV0NST2NDZm1ZL2dpSDkycU1ydTVwL2t5T2l2RTBSQy9JYmRNT052RG9VeWFObU1HUXdIUVlEVlIwT0JCWUVGTlJXR01DSk9PZ09XSVFZeVhaaXY2dTd4WkMrTUI4R0ExVWRJd1FZTUJhQUZOUldHTUNKT09nT1dJUVl5WFppdjZ1N3haQytNQklHQTFVZEV3RUIvd1FJTUFZQkFmOENBUUF3RGdZRFZSMFBBUUgvQkFRREFnR0dNQW9HQ0NxR1NNNDlCQU1DQTBjQU1FUUNJR0VtN3drWktIdC9hdGI0TWRGblhXNnlybndNVVQydTEzNmdkdGwxMFk2aEFpQnVURnF2Vll0aDFyYnh6Q1AweFdaSG1RSzlrVnl4bjhHUGZYMjdFSXp6c3c9PSJdLCJraWQiOiJNSUdVTUlHT3BJR0xNSUdJTVFzd0NRWURWUVFHRXdKRVJURVBNQTBHQTFVRUJ3d0dRbVZ5YkdsdU1SMHdHd1lEVlFRS0RCUkNkVzVrWlhOa2NuVmphMlZ5WldrZ1IyMWlTREVSTUE4R0ExVUVDd3dJVkNCRFV5QkpSRVV4TmpBMEJnTlZCQU1NTFZOUVVrbE9SQ0JHZFc1clpTQkZWVVJKSUZkaGJHeGxkQ0JRY205MGIzUjVjR1VnU1hOemRXbHVaeUJEUVFJQkFnPT0iLCJ0eXAiOiJ2YytzZC1qd3QiLCJhbGciOiJFUzI1NiJ9.eyJ2Y3QiOiJEUklWSU5HX0xJQ0VOQ0UiLCJfc2RfYWxnIjoic2hhLTI1NiIsImlzcyI6Imh0dHBzOi8vZXhhbXBsZS5jb20iLCJjbmYiOnsiandrIjp7Imt0eSI6IkVDIiwiY3J2IjoiUC0yNTYiLCJraWQiOiJITmt1dkQzZjEzM3BvbmRkSXJmWG5mcUNFOE9VQUcwa3BTSmR5c1BWTFFNIiwieCI6IlQ1Vlh2LVFKZjM4QW5YZDk2cXEtajZmY0lXdzV2Y016ajVJZUVhTEJvakkiLCJ5Ijoicmp3SDdCOUZlV3NVaFlEZk1qWng1QmFhS2pVQllnU21Nb0EzOEt2SFpEayJ9fSwiaWF0IjoxNzI0ODY4NDM5fQ.PxjYlyQJYu5tYIwOu-VPsIBFXB1z-WI7_QSRs8mPWeLlPfJ8POs23vZtrcBD-lXFQm38z4QRG9zw_yKYF0qDLw~',
       'eyJ4NWMiOlsiTUlJQ2REQ0NBaHVnQXdJQkFnSUJBakFLQmdncWhrak9QUVFEQWpDQmlERUxNQWtHQTFVRUJoTUNSRVV4RHpBTkJnTlZCQWNNQmtKbGNteHBiakVkTUJzR0ExVUVDZ3dVUW5WdVpHVnpaSEoxWTJ0bGNtVnBJRWR0WWtneEVUQVBCZ05WQkFzTUNGUWdRMU1nU1VSRk1UWXdOQVlEVlFRRERDMVRVRkpKVGtRZ1JuVnVhMlVnUlZWRVNTQlhZV3hzWlhRZ1VISnZkRzkwZVhCbElFbHpjM1ZwYm1jZ1EwRXdIaGNOTWpRd05UTXhNRGd4TXpFM1doY05NalV3TnpBMU1EZ3hNekUzV2pCc01Rc3dDUVlEVlFRR0V3SkVSVEVkTUJzR0ExVUVDZ3dVUW5WdVpHVnpaSEoxWTJ0bGNtVnBJRWR0WWtneENqQUlCZ05WQkFzTUFVa3hNakF3QmdOVkJBTU1LVk5RVWtsT1JDQkdkVzVyWlNCRlZVUkpJRmRoYkd4bGRDQlFjbTkwYjNSNWNHVWdTWE56ZFdWeU1Ga3dFd1lIS29aSXpqMENBUVlJS29aSXpqMERBUWNEUWdBRU9GQnE0WU1LZzR3NWZUaWZzeXR3QnVKZi83RTdWaFJQWGlObTUyUzNxMUVUSWdCZFh5REsza1Z4R3hnZUhQaXZMUDN1dU12UzZpREVjN3FNeG12ZHVLT0JrRENCalRBZEJnTlZIUTRFRmdRVWlQaENrTEVyRFhQTFcyL0owV1ZlZ2h5dyttSXdEQVlEVlIwVEFRSC9CQUl3QURBT0JnTlZIUThCQWY4RUJBTUNCNEF3TFFZRFZSMFJCQ1l3SklJaVpHVnRieTV3YVdRdGFYTnpkV1Z5TG1KMWJtUmxjMlJ5ZFdOclpYSmxhUzVrWlRBZkJnTlZIU01FR0RBV2dCVFVWaGpBaVRqb0RsaUVHTWwyWXIrcnU4V1F2akFLQmdncWhrak9QUVFEQWdOSEFEQkVBaUFiZjVUemtjUXpoZldvSW95aTFWTjdkOEk5QnNGS20xTVdsdVJwaDJieUdRSWdLWWtkck5mMnhYUGpWU2JqVy9VLzVTNXZBRUM1WHhjT2FudXNPQnJvQmJVPSIsIk1JSUNlVENDQWlDZ0F3SUJBZ0lVQjVFOVFWWnRtVVljRHRDaktCL0gzVlF2NzJnd0NnWUlLb1pJemowRUF3SXdnWWd4Q3pBSkJnTlZCQVlUQWtSRk1ROHdEUVlEVlFRSERBWkNaWEpzYVc0eEhUQWJCZ05WQkFvTUZFSjFibVJsYzJSeWRXTnJaWEpsYVNCSGJXSklNUkV3RHdZRFZRUUxEQWhVSUVOVElFbEVSVEUyTURRR0ExVUVBd3d0VTFCU1NVNUVJRVoxYm10bElFVlZSRWtnVjJGc2JHVjBJRkJ5YjNSdmRIbHdaU0JKYzNOMWFXNW5JRU5CTUI0WERUSTBNRFV6TVRBMk5EZ3dPVm9YRFRNME1EVXlPVEEyTkRnd09Wb3dnWWd4Q3pBSkJnTlZCQVlUQWtSRk1ROHdEUVlEVlFRSERBWkNaWEpzYVc0eEhUQWJCZ05WQkFvTUZFSjFibVJsYzJSeWRXTnJaWEpsYVNCSGJXSklNUkV3RHdZRFZRUUxEQWhVSUVOVElFbEVSVEUyTURRR0ExVUVBd3d0VTFCU1NVNUVJRVoxYm10bElFVlZSRWtnVjJGc2JHVjBJRkJ5YjNSdmRIbHdaU0JKYzNOMWFXNW5JRU5CTUZrd0V3WUhLb1pJemowQ0FRWUlLb1pJemowREFRY0RRZ0FFWUd6ZHdGRG5jNytLbjVpYkF2Q09NOGtlNzdWUXhxZk1jd1pMOElhSUErV0NST2NDZm1ZL2dpSDkycU1ydTVwL2t5T2l2RTBSQy9JYmRNT052RG9VeWFObU1HUXdIUVlEVlIwT0JCWUVGTlJXR01DSk9PZ09XSVFZeVhaaXY2dTd4WkMrTUI4R0ExVWRJd1FZTUJhQUZOUldHTUNKT09nT1dJUVl5WFppdjZ1N3haQytNQklHQTFVZEV3RUIvd1FJTUFZQkFmOENBUUF3RGdZRFZSMFBBUUgvQkFRREFnR0dNQW9HQ0NxR1NNNDlCQU1DQTBjQU1FUUNJR0VtN3drWktIdC9hdGI0TWRGblhXNnlybndNVVQydTEzNmdkdGwxMFk2aEFpQnVURnF2Vll0aDFyYnh6Q1AweFdaSG1RSzlrVnl4bjhHUGZYMjdFSXp6c3c9PSJdLCJraWQiOiJNSUdVTUlHT3BJR0xNSUdJTVFzd0NRWURWUVFHRXdKRVJURVBNQTBHQTFVRUJ3d0dRbVZ5YkdsdU1SMHdHd1lEVlFRS0RCUkNkVzVrWlhOa2NuVmphMlZ5WldrZ1IyMWlTREVSTUE4R0ExVUVDd3dJVkNCRFV5QkpSRVV4TmpBMEJnTlZCQU1NTFZOUVVrbE9SQ0JHZFc1clpTQkZWVVJKSUZkaGJHeGxkQ0JRY205MGIzUjVjR1VnU1hOemRXbHVaeUJEUVFJQkFnPT0iLCJ0eXAiOiJ2YytzZC1qd3QiLCJhbGciOiJFUzI1NiJ9.eyJ2Y3QiOiJSRVNJREVOQ0VfUEVSTUlUIiwiX3NkX2FsZyI6InNoYS0yNTYiLCJpc3MiOiJodHRwczovL2V4YW1wbGUuY29tIiwiY25mIjp7Imp3ayI6eyJrdHkiOiJFQyIsImNydiI6IlAtMjU2Iiwia2lkIjoiSE5rdXZEM2YxMzNwb25kZElyZlhuZnFDRThPVUFHMGtwU0pkeXNQVkxRTSIsIngiOiJUNVZYdi1RSmYzOEFuWGQ5NnFxLWo2ZmNJV3c1dmNNemo1SWVFYUxCb2pJIiwieSI6InJqd0g3QjlGZVdzVWhZRGZNalp4NUJhYUtqVUJZZ1NtTW9BMzhLdkhaRGsifX0sImlhdCI6MTcyNDg2ODQzOX0.PxjYlyQJYu5tYIwOu-VPsIBFXB1z-WI7_QSRs8mPWeLlPfJ8POs23vZtrcBD-lXFQm38z4QRG9zw_yKYF0qDLw~',
-    ]
+    ];
     const pd = {
       id: 'OverAgeCheck',
       purpose: 'Age check',
@@ -1252,11 +1256,11 @@ describe('evaluate', () => {
                 path: ['$.vc.type.*', '$.vct', '$.type'],
                 filter: {
                   type: 'string',
-                  const: 'RESIDENCE_PERMIT'
-                }
-              }
-            ]
-          }
+                  const: 'RESIDENCE_PERMIT',
+                },
+              },
+            ],
+          },
         },
         {
           name: 'ID date of birth and photo',
@@ -1268,11 +1272,11 @@ describe('evaluate', () => {
                 path: ['$.vc.type.*', '$.vct', '$.type'],
                 filter: {
                   type: 'string',
-                  const: 'ID'
-                }
-              }
-            ]
-          }
+                  const: 'ID',
+                },
+              },
+            ],
+          },
         },
         {
           name: 'Driving licence date of birth and photo',
@@ -1284,55 +1288,49 @@ describe('evaluate', () => {
                 path: ['$.vc.type.*', '$.vct', '$.type'],
                 filter: {
                   type: 'string',
-                  const: 'DRIVING_LICENCE'
-                }
-              }
-            ]
-          }
-        }
-      ]
-    } satisfies IPresentationDefinition
+                  const: 'DRIVING_LICENCE',
+                },
+              },
+            ],
+          },
+        },
+      ],
+    } satisfies IPresentationDefinition;
     const pex: PEX = new PEX({ hasher });
 
     const result = pex.selectFrom(pd, sdJwtVcs);
 
-    expect(result.matches).toEqual([{
-      "name": "Residence permit date of birth and photo",
-      "rule": "all",
-      "vc_path": [
-        "$.verifiableCredential[0]"
-      ],
-      "type": "InputDescriptor",
-      "id": "ResidencePermit"
-    },
-    {
-      "name": "ID date of birth and photo",
-      "rule": "all",
-      "vc_path": [
-        "$.verifiableCredential[1]"
-      ],
-      "type": "InputDescriptor",
-      "id": "IDDoB"
-    },
-    {
-      "name": "Driving licence date of birth and photo",
-      "rule": "all",
-      "vc_path": [
-        "$.verifiableCredential[2]"
-      ],
-      "type": "InputDescriptor",
-      "id": "DrivingLicenceDoB"
-    }])
-
-
-  })
+    expect(result.matches).toEqual([
+      {
+        name: 'Residence permit date of birth and photo',
+        rule: 'all',
+        vc_path: ['$.verifiableCredential[0]'],
+        type: 'InputDescriptor',
+        id: 'ResidencePermit',
+      },
+      {
+        name: 'ID date of birth and photo',
+        rule: 'all',
+        vc_path: ['$.verifiableCredential[1]'],
+        type: 'InputDescriptor',
+        id: 'IDDoB',
+      },
+      {
+        name: 'Driving licence date of birth and photo',
+        rule: 'all',
+        vc_path: ['$.verifiableCredential[2]'],
+        type: 'InputDescriptor',
+        id: 'DrivingLicenceDoB',
+      },
+    ]);
+  });
 
   it('selectFrom adds index of submission requirement as id and type of match when using submission_requirements', () => {
     const sdJwtVcs = [
       'eyJ4NWMiOlsiTUlJQ2REQ0NBaHVnQXdJQkFnSUJBakFLQmdncWhrak9QUVFEQWpDQmlERUxNQWtHQTFVRUJoTUNSRVV4RHpBTkJnTlZCQWNNQmtKbGNteHBiakVkTUJzR0ExVUVDZ3dVUW5WdVpHVnpaSEoxWTJ0bGNtVnBJRWR0WWtneEVUQVBCZ05WQkFzTUNGUWdRMU1nU1VSRk1UWXdOQVlEVlFRRERDMVRVRkpKVGtRZ1JuVnVhMlVnUlZWRVNTQlhZV3hzWlhRZ1VISnZkRzkwZVhCbElFbHpjM1ZwYm1jZ1EwRXdIaGNOTWpRd05UTXhNRGd4TXpFM1doY05NalV3TnpBMU1EZ3hNekUzV2pCc01Rc3dDUVlEVlFRR0V3SkVSVEVkTUJzR0ExVUVDZ3dVUW5WdVpHVnpaSEoxWTJ0bGNtVnBJRWR0WWtneENqQUlCZ05WQkFzTUFVa3hNakF3QmdOVkJBTU1LVk5RVWtsT1JDQkdkVzVyWlNCRlZVUkpJRmRoYkd4bGRDQlFjbTkwYjNSNWNHVWdTWE56ZFdWeU1Ga3dFd1lIS29aSXpqMENBUVlJS29aSXpqMERBUWNEUWdBRU9GQnE0WU1LZzR3NWZUaWZzeXR3QnVKZi83RTdWaFJQWGlObTUyUzNxMUVUSWdCZFh5REsza1Z4R3hnZUhQaXZMUDN1dU12UzZpREVjN3FNeG12ZHVLT0JrRENCalRBZEJnTlZIUTRFRmdRVWlQaENrTEVyRFhQTFcyL0owV1ZlZ2h5dyttSXdEQVlEVlIwVEFRSC9CQUl3QURBT0JnTlZIUThCQWY4RUJBTUNCNEF3TFFZRFZSMFJCQ1l3SklJaVpHVnRieTV3YVdRdGFYTnpkV1Z5TG1KMWJtUmxjMlJ5ZFdOclpYSmxhUzVrWlRBZkJnTlZIU01FR0RBV2dCVFVWaGpBaVRqb0RsaUVHTWwyWXIrcnU4V1F2akFLQmdncWhrak9QUVFEQWdOSEFEQkVBaUFiZjVUemtjUXpoZldvSW95aTFWTjdkOEk5QnNGS20xTVdsdVJwaDJieUdRSWdLWWtkck5mMnhYUGpWU2JqVy9VLzVTNXZBRUM1WHhjT2FudXNPQnJvQmJVPSIsIk1JSUNlVENDQWlDZ0F3SUJBZ0lVQjVFOVFWWnRtVVljRHRDaktCL0gzVlF2NzJnd0NnWUlLb1pJemowRUF3SXdnWWd4Q3pBSkJnTlZCQVlUQWtSRk1ROHdEUVlEVlFRSERBWkNaWEpzYVc0eEhUQWJCZ05WQkFvTUZFSjFibVJsYzJSeWRXTnJaWEpsYVNCSGJXSklNUkV3RHdZRFZRUUxEQWhVSUVOVElFbEVSVEUyTURRR0ExVUVBd3d0VTFCU1NVNUVJRVoxYm10bElFVlZSRWtnVjJGc2JHVjBJRkJ5YjNSdmRIbHdaU0JKYzNOMWFXNW5JRU5CTUI0WERUSTBNRFV6TVRBMk5EZ3dPVm9YRFRNME1EVXlPVEEyTkRnd09Wb3dnWWd4Q3pBSkJnTlZCQVlUQWtSRk1ROHdEUVlEVlFRSERBWkNaWEpzYVc0eEhUQWJCZ05WQkFvTUZFSjFibVJsYzJSeWRXTnJaWEpsYVNCSGJXSklNUkV3RHdZRFZRUUxEQWhVSUVOVElFbEVSVEUyTURRR0ExVUVBd3d0VTFCU1NVNUVJRVoxYm10bElFVlZSRWtnVjJGc2JHVjBJRkJ5YjNSdmRIbHdaU0JKYzNOMWFXNW5JRU5CTUZrd0V3WUhLb1pJemowQ0FRWUlLb1pJemowREFRY0RRZ0FFWUd6ZHdGRG5jNytLbjVpYkF2Q09NOGtlNzdWUXhxZk1jd1pMOElhSUErV0NST2NDZm1ZL2dpSDkycU1ydTVwL2t5T2l2RTBSQy9JYmRNT052RG9VeWFObU1HUXdIUVlEVlIwT0JCWUVGTlJXR01DSk9PZ09XSVFZeVhaaXY2dTd4WkMrTUI4R0ExVWRJd1FZTUJhQUZOUldHTUNKT09nT1dJUVl5WFppdjZ1N3haQytNQklHQTFVZEV3RUIvd1FJTUFZQkFmOENBUUF3RGdZRFZSMFBBUUgvQkFRREFnR0dNQW9HQ0NxR1NNNDlCQU1DQTBjQU1FUUNJR0VtN3drWktIdC9hdGI0TWRGblhXNnlybndNVVQydTEzNmdkdGwxMFk2aEFpQnVURnF2Vll0aDFyYnh6Q1AweFdaSG1RSzlrVnl4bjhHUGZYMjdFSXp6c3c9PSJdLCJraWQiOiJNSUdVTUlHT3BJR0xNSUdJTVFzd0NRWURWUVFHRXdKRVJURVBNQTBHQTFVRUJ3d0dRbVZ5YkdsdU1SMHdHd1lEVlFRS0RCUkNkVzVrWlhOa2NuVmphMlZ5WldrZ1IyMWlTREVSTUE4R0ExVUVDd3dJVkNCRFV5QkpSRVV4TmpBMEJnTlZCQU1NTFZOUVVrbE9SQ0JHZFc1clpTQkZWVVJKSUZkaGJHeGxkQ0JRY205MGIzUjVjR1VnU1hOemRXbHVaeUJEUVFJQkFnPT0iLCJ0eXAiOiJ2YytzZC1qd3QiLCJhbGciOiJFUzI1NiJ9.eyJ2Y3QiOiJJRCIsIl9zZF9hbGciOiJzaGEtMjU2IiwiaXNzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbSIsImNuZiI6eyJqd2siOnsia3R5IjoiRUMiLCJjcnYiOiJQLTI1NiIsImtpZCI6IkhOa3V2RDNmMTMzcG9uZGRJcmZYbmZxQ0U4T1VBRzBrcFNKZHlzUFZMUU0iLCJ4IjoiVDVWWHYtUUpmMzhBblhkOTZxcS1qNmZjSVd3NXZjTXpqNUllRWFMQm9qSSIsInkiOiJyandIN0I5RmVXc1VoWURmTWpaeDVCYWFLalVCWWdTbU1vQTM4S3ZIWkRrIn19LCJpYXQiOjE3MjQ4Njg0Mzl9.PxjYlyQJYu5tYIwOu-VPsIBFXB1z-WI7_QSRs8mPWeLlPfJ8POs23vZtrcBD-lXFQm38z4QRG9zw_yKYF0qDLw~',
       'eyJ4NWMiOlsiTUlJQ2REQ0NBaHVnQXdJQkFnSUJBakFLQmdncWhrak9QUVFEQWpDQmlERUxNQWtHQTFVRUJoTUNSRVV4RHpBTkJnTlZCQWNNQmtKbGNteHBiakVkTUJzR0ExVUVDZ3dVUW5WdVpHVnpaSEoxWTJ0bGNtVnBJRWR0WWtneEVUQVBCZ05WQkFzTUNGUWdRMU1nU1VSRk1UWXdOQVlEVlFRRERDMVRVRkpKVGtRZ1JuVnVhMlVnUlZWRVNTQlhZV3hzWlhRZ1VISnZkRzkwZVhCbElFbHpjM1ZwYm1jZ1EwRXdIaGNOTWpRd05UTXhNRGd4TXpFM1doY05NalV3TnpBMU1EZ3hNekUzV2pCc01Rc3dDUVlEVlFRR0V3SkVSVEVkTUJzR0ExVUVDZ3dVUW5WdVpHVnpaSEoxWTJ0bGNtVnBJRWR0WWtneENqQUlCZ05WQkFzTUFVa3hNakF3QmdOVkJBTU1LVk5RVWtsT1JDQkdkVzVyWlNCRlZVUkpJRmRoYkd4bGRDQlFjbTkwYjNSNWNHVWdTWE56ZFdWeU1Ga3dFd1lIS29aSXpqMENBUVlJS29aSXpqMERBUWNEUWdBRU9GQnE0WU1LZzR3NWZUaWZzeXR3QnVKZi83RTdWaFJQWGlObTUyUzNxMUVUSWdCZFh5REsza1Z4R3hnZUhQaXZMUDN1dU12UzZpREVjN3FNeG12ZHVLT0JrRENCalRBZEJnTlZIUTRFRmdRVWlQaENrTEVyRFhQTFcyL0owV1ZlZ2h5dyttSXdEQVlEVlIwVEFRSC9CQUl3QURBT0JnTlZIUThCQWY4RUJBTUNCNEF3TFFZRFZSMFJCQ1l3SklJaVpHVnRieTV3YVdRdGFYTnpkV1Z5TG1KMWJtUmxjMlJ5ZFdOclpYSmxhUzVrWlRBZkJnTlZIU01FR0RBV2dCVFVWaGpBaVRqb0RsaUVHTWwyWXIrcnU4V1F2akFLQmdncWhrak9QUVFEQWdOSEFEQkVBaUFiZjVUemtjUXpoZldvSW95aTFWTjdkOEk5QnNGS20xTVdsdVJwaDJieUdRSWdLWWtkck5mMnhYUGpWU2JqVy9VLzVTNXZBRUM1WHhjT2FudXNPQnJvQmJVPSIsIk1JSUNlVENDQWlDZ0F3SUJBZ0lVQjVFOVFWWnRtVVljRHRDaktCL0gzVlF2NzJnd0NnWUlLb1pJemowRUF3SXdnWWd4Q3pBSkJnTlZCQVlUQWtSRk1ROHdEUVlEVlFRSERBWkNaWEpzYVc0eEhUQWJCZ05WQkFvTUZFSjFibVJsYzJSeWRXTnJaWEpsYVNCSGJXSklNUkV3RHdZRFZRUUxEQWhVSUVOVElFbEVSVEUyTURRR0ExVUVBd3d0VTFCU1NVNUVJRVoxYm10bElFVlZSRWtnVjJGc2JHVjBJRkJ5YjNSdmRIbHdaU0JKYzNOMWFXNW5JRU5CTUI0WERUSTBNRFV6TVRBMk5EZ3dPVm9YRFRNME1EVXlPVEEyTkRnd09Wb3dnWWd4Q3pBSkJnTlZCQVlUQWtSRk1ROHdEUVlEVlFRSERBWkNaWEpzYVc0eEhUQWJCZ05WQkFvTUZFSjFibVJsYzJSeWRXTnJaWEpsYVNCSGJXSklNUkV3RHdZRFZRUUxEQWhVSUVOVElFbEVSVEUyTURRR0ExVUVBd3d0VTFCU1NVNUVJRVoxYm10bElFVlZSRWtnVjJGc2JHVjBJRkJ5YjNSdmRIbHdaU0JKYzNOMWFXNW5JRU5CTUZrd0V3WUhLb1pJemowQ0FRWUlLb1pJemowREFRY0RRZ0FFWUd6ZHdGRG5jNytLbjVpYkF2Q09NOGtlNzdWUXhxZk1jd1pMOElhSUErV0NST2NDZm1ZL2dpSDkycU1ydTVwL2t5T2l2RTBSQy9JYmRNT052RG9VeWFObU1HUXdIUVlEVlIwT0JCWUVGTlJXR01DSk9PZ09XSVFZeVhaaXY2dTd4WkMrTUI4R0ExVWRJd1FZTUJhQUZOUldHTUNKT09nT1dJUVl5WFppdjZ1N3haQytNQklHQTFVZEV3RUIvd1FJTUFZQkFmOENBUUF3RGdZRFZSMFBBUUgvQkFRREFnR0dNQW9HQ0NxR1NNNDlCQU1DQTBjQU1FUUNJR0VtN3drWktIdC9hdGI0TWRGblhXNnlybndNVVQydTEzNmdkdGwxMFk2aEFpQnVURnF2Vll0aDFyYnh6Q1AweFdaSG1RSzlrVnl4bjhHUGZYMjdFSXp6c3c9PSJdLCJraWQiOiJNSUdVTUlHT3BJR0xNSUdJTVFzd0NRWURWUVFHRXdKRVJURVBNQTBHQTFVRUJ3d0dRbVZ5YkdsdU1SMHdHd1lEVlFRS0RCUkNkVzVrWlhOa2NuVmphMlZ5WldrZ1IyMWlTREVSTUE4R0ExVUVDd3dJVkNCRFV5QkpSRVV4TmpBMEJnTlZCQU1NTFZOUVVrbE9SQ0JHZFc1clpTQkZWVVJKSUZkaGJHeGxkQ0JRY205MGIzUjVjR1VnU1hOemRXbHVaeUJEUVFJQkFnPT0iLCJ0eXAiOiJ2YytzZC1qd3QiLCJhbGciOiJFUzI1NiJ9.eyJ2Y3QiOiJEUklWSU5HX0xJQ0VOQ0UiLCJfc2RfYWxnIjoic2hhLTI1NiIsImlzcyI6Imh0dHBzOi8vZXhhbXBsZS5jb20iLCJjbmYiOnsiandrIjp7Imt0eSI6IkVDIiwiY3J2IjoiUC0yNTYiLCJraWQiOiJITmt1dkQzZjEzM3BvbmRkSXJmWG5mcUNFOE9VQUcwa3BTSmR5c1BWTFFNIiwieCI6IlQ1Vlh2LVFKZjM4QW5YZDk2cXEtajZmY0lXdzV2Y016ajVJZUVhTEJvakkiLCJ5Ijoicmp3SDdCOUZlV3NVaFlEZk1qWng1QmFhS2pVQllnU21Nb0EzOEt2SFpEayJ9fSwiaWF0IjoxNzI0ODY4NDM5fQ.PxjYlyQJYu5tYIwOu-VPsIBFXB1z-WI7_QSRs8mPWeLlPfJ8POs23vZtrcBD-lXFQm38z4QRG9zw_yKYF0qDLw~',
       'eyJ4NWMiOlsiTUlJQ2REQ0NBaHVnQXdJQkFnSUJBakFLQmdncWhrak9QUVFEQWpDQmlERUxNQWtHQTFVRUJoTUNSRVV4RHpBTkJnTlZCQWNNQmtKbGNteHBiakVkTUJzR0ExVUVDZ3dVUW5WdVpHVnpaSEoxWTJ0bGNtVnBJRWR0WWtneEVUQVBCZ05WQkFzTUNGUWdRMU1nU1VSRk1UWXdOQVlEVlFRRERDMVRVRkpKVGtRZ1JuVnVhMlVnUlZWRVNTQlhZV3hzWlhRZ1VISnZkRzkwZVhCbElFbHpjM1ZwYm1jZ1EwRXdIaGNOTWpRd05UTXhNRGd4TXpFM1doY05NalV3TnpBMU1EZ3hNekUzV2pCc01Rc3dDUVlEVlFRR0V3SkVSVEVkTUJzR0ExVUVDZ3dVUW5WdVpHVnpaSEoxWTJ0bGNtVnBJRWR0WWtneENqQUlCZ05WQkFzTUFVa3hNakF3QmdOVkJBTU1LVk5RVWtsT1JDQkdkVzVyWlNCRlZVUkpJRmRoYkd4bGRDQlFjbTkwYjNSNWNHVWdTWE56ZFdWeU1Ga3dFd1lIS29aSXpqMENBUVlJS29aSXpqMERBUWNEUWdBRU9GQnE0WU1LZzR3NWZUaWZzeXR3QnVKZi83RTdWaFJQWGlObTUyUzNxMUVUSWdCZFh5REsza1Z4R3hnZUhQaXZMUDN1dU12UzZpREVjN3FNeG12ZHVLT0JrRENCalRBZEJnTlZIUTRFRmdRVWlQaENrTEVyRFhQTFcyL0owV1ZlZ2h5dyttSXdEQVlEVlIwVEFRSC9CQUl3QURBT0JnTlZIUThCQWY4RUJBTUNCNEF3TFFZRFZSMFJCQ1l3SklJaVpHVnRieTV3YVdRdGFYTnpkV1Z5TG1KMWJtUmxjMlJ5ZFdOclpYSmxhUzVrWlRBZkJnTlZIU01FR0RBV2dCVFVWaGpBaVRqb0RsaUVHTWwyWXIrcnU4V1F2akFLQmdncWhrak9QUVFEQWdOSEFEQkVBaUFiZjVUemtjUXpoZldvSW95aTFWTjdkOEk5QnNGS20xTVdsdVJwaDJieUdRSWdLWWtkck5mMnhYUGpWU2JqVy9VLzVTNXZBRUM1WHhjT2FudXNPQnJvQmJVPSIsIk1JSUNlVENDQWlDZ0F3SUJBZ0lVQjVFOVFWWnRtVVljRHRDaktCL0gzVlF2NzJnd0NnWUlLb1pJemowRUF3SXdnWWd4Q3pBSkJnTlZCQVlUQWtSRk1ROHdEUVlEVlFRSERBWkNaWEpzYVc0eEhUQWJCZ05WQkFvTUZFSjFibVJsYzJSeWRXTnJaWEpsYVNCSGJXSklNUkV3RHdZRFZRUUxEQWhVSUVOVElFbEVSVEUyTURRR0ExVUVBd3d0VTFCU1NVNUVJRVoxYm10bElFVlZSRWtnVjJGc2JHVjBJRkJ5YjNSdmRIbHdaU0JKYzNOMWFXNW5JRU5CTUI0WERUSTBNRFV6TVRBMk5EZ3dPVm9YRFRNME1EVXlPVEEyTkRnd09Wb3dnWWd4Q3pBSkJnTlZCQVlUQWtSRk1ROHdEUVlEVlFRSERBWkNaWEpzYVc0eEhUQWJCZ05WQkFvTUZFSjFibVJsYzJSeWRXTnJaWEpsYVNCSGJXSklNUkV3RHdZRFZRUUxEQWhVSUVOVElFbEVSVEUyTURRR0ExVUVBd3d0VTFCU1NVNUVJRVoxYm10bElFVlZSRWtnVjJGc2JHVjBJRkJ5YjNSdmRIbHdaU0JKYzNOMWFXNW5JRU5CTUZrd0V3WUhLb1pJemowQ0FRWUlLb1pJemowREFRY0RRZ0FFWUd6ZHdGRG5jNytLbjVpYkF2Q09NOGtlNzdWUXhxZk1jd1pMOElhSUErV0NST2NDZm1ZL2dpSDkycU1ydTVwL2t5T2l2RTBSQy9JYmRNT052RG9VeWFObU1HUXdIUVlEVlIwT0JCWUVGTlJXR01DSk9PZ09XSVFZeVhaaXY2dTd4WkMrTUI4R0ExVWRJd1FZTUJhQUZOUldHTUNKT09nT1dJUVl5WFppdjZ1N3haQytNQklHQTFVZEV3RUIvd1FJTUFZQkFmOENBUUF3RGdZRFZSMFBBUUgvQkFRREFnR0dNQW9HQ0NxR1NNNDlCQU1DQTBjQU1FUUNJR0VtN3drWktIdC9hdGI0TWRGblhXNnlybndNVVQydTEzNmdkdGwxMFk2aEFpQnVURnF2Vll0aDFyYnh6Q1AweFdaSG1RSzlrVnl4bjhHUGZYMjdFSXp6c3c9PSJdLCJraWQiOiJNSUdVTUlHT3BJR0xNSUdJTVFzd0NRWURWUVFHRXdKRVJURVBNQTBHQTFVRUJ3d0dRbVZ5YkdsdU1SMHdHd1lEVlFRS0RCUkNkVzVrWlhOa2NuVmphMlZ5WldrZ1IyMWlTREVSTUE4R0ExVUVDd3dJVkNCRFV5QkpSRVV4TmpBMEJnTlZCQU1NTFZOUVVrbE9SQ0JHZFc1clpTQkZWVVJKSUZkaGJHeGxkQ0JRY205MGIzUjVjR1VnU1hOemRXbHVaeUJEUVFJQkFnPT0iLCJ0eXAiOiJ2YytzZC1qd3QiLCJhbGciOiJFUzI1NiJ9.eyJ2Y3QiOiJSRVNJREVOQ0VfUEVSTUlUIiwiX3NkX2FsZyI6InNoYS0yNTYiLCJpc3MiOiJodHRwczovL2V4YW1wbGUuY29tIiwiY25mIjp7Imp3ayI6eyJrdHkiOiJFQyIsImNydiI6IlAtMjU2Iiwia2lkIjoiSE5rdXZEM2YxMzNwb25kZElyZlhuZnFDRThPVUFHMGtwU0pkeXNQVkxRTSIsIngiOiJUNVZYdi1RSmYzOEFuWGQ5NnFxLWo2ZmNJV3c1dmNNemo1SWVFYUxCb2pJIiwieSI6InJqd0g3QjlGZVdzVWhZRGZNalp4NUJhYUtqVUJZZ1NtTW9BMzhLdkhaRGsifX0sImlhdCI6MTcyNDg2ODQzOX0.PxjYlyQJYu5tYIwOu-VPsIBFXB1z-WI7_QSRs8mPWeLlPfJ8POs23vZtrcBD-lXFQm38z4QRG9zw_yKYF0qDLw~',
-    ]
+    ];
     const pd = {
       id: 'OverAgeCheck',
       purpose: 'Age check',
@@ -1341,14 +1339,14 @@ describe('evaluate', () => {
           name: 'Proof of age and photo',
           rule: 'pick',
           count: 1,
-          from: 'validAgeCheckInputDescriptor'
+          from: 'validAgeCheckInputDescriptor',
         },
         {
           name: 'Proof of other',
           rule: 'pick',
           count: 1,
-          from: 'validOtherCheck'
-        }
+          from: 'validOtherCheck',
+        },
       ],
       input_descriptors: [
         {
@@ -1362,11 +1360,11 @@ describe('evaluate', () => {
                 path: ['$.vc.type.*', '$.vct', '$.type'],
                 filter: {
                   type: 'string',
-                  const: 'RESIDENCE_PERMIT'
-                }
-              }
-            ]
-          }
+                  const: 'RESIDENCE_PERMIT',
+                },
+              },
+            ],
+          },
         },
         {
           name: 'ID date of birth and photo',
@@ -1379,11 +1377,11 @@ describe('evaluate', () => {
                 path: ['$.vc.type.*', '$.vct', '$.type'],
                 filter: {
                   type: 'string',
-                  const: 'ID'
-                }
-              }
-            ]
-          }
+                  const: 'ID',
+                },
+              },
+            ],
+          },
         },
         {
           name: 'Driving licence date of birth and photo',
@@ -1396,45 +1394,39 @@ describe('evaluate', () => {
                 path: ['$.vc.type.*', '$.vct', '$.type'],
                 filter: {
                   type: 'string',
-                  const: 'DRIVING_LICENCE'
-                }
-              }
-            ]
-          }
-        }
-      ]
-    } satisfies IPresentationDefinition
+                  const: 'DRIVING_LICENCE',
+                },
+              },
+            ],
+          },
+        },
+      ],
+    } satisfies IPresentationDefinition;
     const pex: PEX = new PEX({ hasher });
 
     const result = pex.selectFrom(pd, sdJwtVcs);
 
-    expect(result.matches).toEqual([{
-      "rule": "pick",
-      "vc_path": [
-        "$.verifiableCredential[0]",
-        "$.verifiableCredential[1]"
-      ],
-      "name": "Proof of age and photo",
-      "type": "SubmissionRequirement",
-      "id": 0,
-      "from": "validAgeCheckInputDescriptor",
-      "count": 1
-    },
-    {
-      "rule": "pick",
-      "vc_path": [
-        "$.verifiableCredential[2]",
-        "$.verifiableCredential[0]"
-      ],
-      "name": "Proof of other",
-      "type": "SubmissionRequirement",
-      "id": 1,
-      "from": "validOtherCheck",
-      "count": 1
-    }])
-
-
-  })
+    expect(result.matches).toEqual([
+      {
+        rule: 'pick',
+        vc_path: ['$.verifiableCredential[0]', '$.verifiableCredential[1]'],
+        name: 'Proof of age and photo',
+        type: 'SubmissionRequirement',
+        id: 0,
+        from: 'validAgeCheckInputDescriptor',
+        count: 1,
+      },
+      {
+        rule: 'pick',
+        vc_path: ['$.verifiableCredential[2]', '$.verifiableCredential[0]'],
+        name: 'Proof of other',
+        type: 'SubmissionRequirement',
+        id: 1,
+        from: 'validOtherCheck',
+        count: 1,
+      },
+    ]);
+  });
 
   it('should map the sd-jwt credential correctly with the indices of selecFrom result', () => {
     const sdJwt: OriginalVerifiableCredential =

--- a/test/PEX.spec.ts
+++ b/test/PEX.spec.ts
@@ -944,8 +944,7 @@ describe('evaluate', () => {
     const jwtVc: IVerifiableCredential = getFileAsJson('test/dif_pe_examples/vp/vp_general.json').verifiableCredential[0];
     jwtVc['iss' as keyof IVerifiableCredential] = 'did:test:456';
     expect(() => SSITypesBuilder.mapExternalVerifiableCredentialsToWrappedVcs([jwtVc])).toThrowError(
-      `Inconsistent issuers between JWT claim (${jwtVc['iss' as keyof IVerifiableCredential]}) and VC value (${
-        (<ICredential>jwtVc['vc' as keyof IVerifiableCredential]).issuer
+      `Inconsistent issuers between JWT claim (${jwtVc['iss' as keyof IVerifiableCredential]}) and VC value (${(<ICredential>jwtVc['vc' as keyof IVerifiableCredential]).issuer
       })`,
     );
   });
@@ -966,8 +965,7 @@ describe('evaluate', () => {
     jwtVc['nbf' as keyof IVerifiableCredential] = nbf / 1000;
     (<ICredential>jwtVc['vc' as keyof IVerifiableCredential]).issuanceDate = new Date(+new Date() + 2000).toISOString();
     expect(() => SSITypesBuilder.mapExternalVerifiableCredentialsToWrappedVcs([jwtVc])).toThrowError(
-      `Inconsistent issuance dates between JWT claim (${new Date(nbf).toISOString().replace(/\.\d\d\dZ/, 'Z')}) and VC value (${
-        (<ICredential>jwtVc['vc' as keyof IVerifiableCredential]).issuanceDate
+      `Inconsistent issuance dates between JWT claim (${new Date(nbf).toISOString().replace(/\.\d\d\dZ/, 'Z')}) and VC value (${(<ICredential>jwtVc['vc' as keyof IVerifiableCredential]).issuanceDate
       })`,
     );
   });
@@ -985,8 +983,7 @@ describe('evaluate', () => {
     const jwtVc: IVerifiableCredential = getFileAsJson('test/dif_pe_examples/vp/vp_general.json').verifiableCredential[0];
     jwtVc['sub' as keyof IVerifiableCredential] = 'did:test:123';
     expect(() => SSITypesBuilder.mapExternalVerifiableCredentialsToWrappedVcs([jwtVc])).toThrowError(
-      `Inconsistent credential subject ids between JWT claim (${jwtVc['sub' as keyof IVerifiableCredential]}) and VC value (${
-        ((<ICredential>jwtVc['vc' as keyof IVerifiableCredential]).credentialSubject as ICredentialSubject).id
+      `Inconsistent credential subject ids between JWT claim (${jwtVc['sub' as keyof IVerifiableCredential]}) and VC value (${((<ICredential>jwtVc['vc' as keyof IVerifiableCredential]).credentialSubject as ICredentialSubject).id
       })`,
     );
   });
@@ -1002,8 +999,7 @@ describe('evaluate', () => {
     const jwtVc: IVerifiableCredential = getFileAsJson('test/dif_pe_examples/vp/vp_general.json').verifiableCredential[0];
     jwtVc['jti' as keyof IVerifiableCredential] = 'test';
     expect(() => SSITypesBuilder.mapExternalVerifiableCredentialsToWrappedVcs([jwtVc])).toThrowError(
-      `Inconsistent credential ids between JWT claim (${jwtVc['jti' as keyof IVerifiableCredential]}) and VC value (${
-        (<ICredential>jwtVc['vc' as keyof IVerifiableCredential]).id
+      `Inconsistent credential ids between JWT claim (${jwtVc['jti' as keyof IVerifiableCredential]}) and VC value (${(<ICredential>jwtVc['vc' as keyof IVerifiableCredential]).id
       })`,
     );
   });
@@ -1235,6 +1231,210 @@ describe('evaluate', () => {
       },
     ]);
   });
+
+  it('selectFrom adds id of input descriptor and type of match when not using submission_requirements', () => {
+    const sdJwtVcs = [
+      'eyJ4NWMiOlsiTUlJQ2REQ0NBaHVnQXdJQkFnSUJBakFLQmdncWhrak9QUVFEQWpDQmlERUxNQWtHQTFVRUJoTUNSRVV4RHpBTkJnTlZCQWNNQmtKbGNteHBiakVkTUJzR0ExVUVDZ3dVUW5WdVpHVnpaSEoxWTJ0bGNtVnBJRWR0WWtneEVUQVBCZ05WQkFzTUNGUWdRMU1nU1VSRk1UWXdOQVlEVlFRRERDMVRVRkpKVGtRZ1JuVnVhMlVnUlZWRVNTQlhZV3hzWlhRZ1VISnZkRzkwZVhCbElFbHpjM1ZwYm1jZ1EwRXdIaGNOTWpRd05UTXhNRGd4TXpFM1doY05NalV3TnpBMU1EZ3hNekUzV2pCc01Rc3dDUVlEVlFRR0V3SkVSVEVkTUJzR0ExVUVDZ3dVUW5WdVpHVnpaSEoxWTJ0bGNtVnBJRWR0WWtneENqQUlCZ05WQkFzTUFVa3hNakF3QmdOVkJBTU1LVk5RVWtsT1JDQkdkVzVyWlNCRlZVUkpJRmRoYkd4bGRDQlFjbTkwYjNSNWNHVWdTWE56ZFdWeU1Ga3dFd1lIS29aSXpqMENBUVlJS29aSXpqMERBUWNEUWdBRU9GQnE0WU1LZzR3NWZUaWZzeXR3QnVKZi83RTdWaFJQWGlObTUyUzNxMUVUSWdCZFh5REsza1Z4R3hnZUhQaXZMUDN1dU12UzZpREVjN3FNeG12ZHVLT0JrRENCalRBZEJnTlZIUTRFRmdRVWlQaENrTEVyRFhQTFcyL0owV1ZlZ2h5dyttSXdEQVlEVlIwVEFRSC9CQUl3QURBT0JnTlZIUThCQWY4RUJBTUNCNEF3TFFZRFZSMFJCQ1l3SklJaVpHVnRieTV3YVdRdGFYTnpkV1Z5TG1KMWJtUmxjMlJ5ZFdOclpYSmxhUzVrWlRBZkJnTlZIU01FR0RBV2dCVFVWaGpBaVRqb0RsaUVHTWwyWXIrcnU4V1F2akFLQmdncWhrak9QUVFEQWdOSEFEQkVBaUFiZjVUemtjUXpoZldvSW95aTFWTjdkOEk5QnNGS20xTVdsdVJwaDJieUdRSWdLWWtkck5mMnhYUGpWU2JqVy9VLzVTNXZBRUM1WHhjT2FudXNPQnJvQmJVPSIsIk1JSUNlVENDQWlDZ0F3SUJBZ0lVQjVFOVFWWnRtVVljRHRDaktCL0gzVlF2NzJnd0NnWUlLb1pJemowRUF3SXdnWWd4Q3pBSkJnTlZCQVlUQWtSRk1ROHdEUVlEVlFRSERBWkNaWEpzYVc0eEhUQWJCZ05WQkFvTUZFSjFibVJsYzJSeWRXTnJaWEpsYVNCSGJXSklNUkV3RHdZRFZRUUxEQWhVSUVOVElFbEVSVEUyTURRR0ExVUVBd3d0VTFCU1NVNUVJRVoxYm10bElFVlZSRWtnVjJGc2JHVjBJRkJ5YjNSdmRIbHdaU0JKYzNOMWFXNW5JRU5CTUI0WERUSTBNRFV6TVRBMk5EZ3dPVm9YRFRNME1EVXlPVEEyTkRnd09Wb3dnWWd4Q3pBSkJnTlZCQVlUQWtSRk1ROHdEUVlEVlFRSERBWkNaWEpzYVc0eEhUQWJCZ05WQkFvTUZFSjFibVJsYzJSeWRXTnJaWEpsYVNCSGJXSklNUkV3RHdZRFZRUUxEQWhVSUVOVElFbEVSVEUyTURRR0ExVUVBd3d0VTFCU1NVNUVJRVoxYm10bElFVlZSRWtnVjJGc2JHVjBJRkJ5YjNSdmRIbHdaU0JKYzNOMWFXNW5JRU5CTUZrd0V3WUhLb1pJemowQ0FRWUlLb1pJemowREFRY0RRZ0FFWUd6ZHdGRG5jNytLbjVpYkF2Q09NOGtlNzdWUXhxZk1jd1pMOElhSUErV0NST2NDZm1ZL2dpSDkycU1ydTVwL2t5T2l2RTBSQy9JYmRNT052RG9VeWFObU1HUXdIUVlEVlIwT0JCWUVGTlJXR01DSk9PZ09XSVFZeVhaaXY2dTd4WkMrTUI4R0ExVWRJd1FZTUJhQUZOUldHTUNKT09nT1dJUVl5WFppdjZ1N3haQytNQklHQTFVZEV3RUIvd1FJTUFZQkFmOENBUUF3RGdZRFZSMFBBUUgvQkFRREFnR0dNQW9HQ0NxR1NNNDlCQU1DQTBjQU1FUUNJR0VtN3drWktIdC9hdGI0TWRGblhXNnlybndNVVQydTEzNmdkdGwxMFk2aEFpQnVURnF2Vll0aDFyYnh6Q1AweFdaSG1RSzlrVnl4bjhHUGZYMjdFSXp6c3c9PSJdLCJraWQiOiJNSUdVTUlHT3BJR0xNSUdJTVFzd0NRWURWUVFHRXdKRVJURVBNQTBHQTFVRUJ3d0dRbVZ5YkdsdU1SMHdHd1lEVlFRS0RCUkNkVzVrWlhOa2NuVmphMlZ5WldrZ1IyMWlTREVSTUE4R0ExVUVDd3dJVkNCRFV5QkpSRVV4TmpBMEJnTlZCQU1NTFZOUVVrbE9SQ0JHZFc1clpTQkZWVVJKSUZkaGJHeGxkQ0JRY205MGIzUjVjR1VnU1hOemRXbHVaeUJEUVFJQkFnPT0iLCJ0eXAiOiJ2YytzZC1qd3QiLCJhbGciOiJFUzI1NiJ9.eyJ2Y3QiOiJJRCIsIl9zZF9hbGciOiJzaGEtMjU2IiwiaXNzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbSIsImNuZiI6eyJqd2siOnsia3R5IjoiRUMiLCJjcnYiOiJQLTI1NiIsImtpZCI6IkhOa3V2RDNmMTMzcG9uZGRJcmZYbmZxQ0U4T1VBRzBrcFNKZHlzUFZMUU0iLCJ4IjoiVDVWWHYtUUpmMzhBblhkOTZxcS1qNmZjSVd3NXZjTXpqNUllRWFMQm9qSSIsInkiOiJyandIN0I5RmVXc1VoWURmTWpaeDVCYWFLalVCWWdTbU1vQTM4S3ZIWkRrIn19LCJpYXQiOjE3MjQ4Njg0Mzl9.PxjYlyQJYu5tYIwOu-VPsIBFXB1z-WI7_QSRs8mPWeLlPfJ8POs23vZtrcBD-lXFQm38z4QRG9zw_yKYF0qDLw~',
+      'eyJ4NWMiOlsiTUlJQ2REQ0NBaHVnQXdJQkFnSUJBakFLQmdncWhrak9QUVFEQWpDQmlERUxNQWtHQTFVRUJoTUNSRVV4RHpBTkJnTlZCQWNNQmtKbGNteHBiakVkTUJzR0ExVUVDZ3dVUW5WdVpHVnpaSEoxWTJ0bGNtVnBJRWR0WWtneEVUQVBCZ05WQkFzTUNGUWdRMU1nU1VSRk1UWXdOQVlEVlFRRERDMVRVRkpKVGtRZ1JuVnVhMlVnUlZWRVNTQlhZV3hzWlhRZ1VISnZkRzkwZVhCbElFbHpjM1ZwYm1jZ1EwRXdIaGNOTWpRd05UTXhNRGd4TXpFM1doY05NalV3TnpBMU1EZ3hNekUzV2pCc01Rc3dDUVlEVlFRR0V3SkVSVEVkTUJzR0ExVUVDZ3dVUW5WdVpHVnpaSEoxWTJ0bGNtVnBJRWR0WWtneENqQUlCZ05WQkFzTUFVa3hNakF3QmdOVkJBTU1LVk5RVWtsT1JDQkdkVzVyWlNCRlZVUkpJRmRoYkd4bGRDQlFjbTkwYjNSNWNHVWdTWE56ZFdWeU1Ga3dFd1lIS29aSXpqMENBUVlJS29aSXpqMERBUWNEUWdBRU9GQnE0WU1LZzR3NWZUaWZzeXR3QnVKZi83RTdWaFJQWGlObTUyUzNxMUVUSWdCZFh5REsza1Z4R3hnZUhQaXZMUDN1dU12UzZpREVjN3FNeG12ZHVLT0JrRENCalRBZEJnTlZIUTRFRmdRVWlQaENrTEVyRFhQTFcyL0owV1ZlZ2h5dyttSXdEQVlEVlIwVEFRSC9CQUl3QURBT0JnTlZIUThCQWY4RUJBTUNCNEF3TFFZRFZSMFJCQ1l3SklJaVpHVnRieTV3YVdRdGFYTnpkV1Z5TG1KMWJtUmxjMlJ5ZFdOclpYSmxhUzVrWlRBZkJnTlZIU01FR0RBV2dCVFVWaGpBaVRqb0RsaUVHTWwyWXIrcnU4V1F2akFLQmdncWhrak9QUVFEQWdOSEFEQkVBaUFiZjVUemtjUXpoZldvSW95aTFWTjdkOEk5QnNGS20xTVdsdVJwaDJieUdRSWdLWWtkck5mMnhYUGpWU2JqVy9VLzVTNXZBRUM1WHhjT2FudXNPQnJvQmJVPSIsIk1JSUNlVENDQWlDZ0F3SUJBZ0lVQjVFOVFWWnRtVVljRHRDaktCL0gzVlF2NzJnd0NnWUlLb1pJemowRUF3SXdnWWd4Q3pBSkJnTlZCQVlUQWtSRk1ROHdEUVlEVlFRSERBWkNaWEpzYVc0eEhUQWJCZ05WQkFvTUZFSjFibVJsYzJSeWRXTnJaWEpsYVNCSGJXSklNUkV3RHdZRFZRUUxEQWhVSUVOVElFbEVSVEUyTURRR0ExVUVBd3d0VTFCU1NVNUVJRVoxYm10bElFVlZSRWtnVjJGc2JHVjBJRkJ5YjNSdmRIbHdaU0JKYzNOMWFXNW5JRU5CTUI0WERUSTBNRFV6TVRBMk5EZ3dPVm9YRFRNME1EVXlPVEEyTkRnd09Wb3dnWWd4Q3pBSkJnTlZCQVlUQWtSRk1ROHdEUVlEVlFRSERBWkNaWEpzYVc0eEhUQWJCZ05WQkFvTUZFSjFibVJsYzJSeWRXTnJaWEpsYVNCSGJXSklNUkV3RHdZRFZRUUxEQWhVSUVOVElFbEVSVEUyTURRR0ExVUVBd3d0VTFCU1NVNUVJRVoxYm10bElFVlZSRWtnVjJGc2JHVjBJRkJ5YjNSdmRIbHdaU0JKYzNOMWFXNW5JRU5CTUZrd0V3WUhLb1pJemowQ0FRWUlLb1pJemowREFRY0RRZ0FFWUd6ZHdGRG5jNytLbjVpYkF2Q09NOGtlNzdWUXhxZk1jd1pMOElhSUErV0NST2NDZm1ZL2dpSDkycU1ydTVwL2t5T2l2RTBSQy9JYmRNT052RG9VeWFObU1HUXdIUVlEVlIwT0JCWUVGTlJXR01DSk9PZ09XSVFZeVhaaXY2dTd4WkMrTUI4R0ExVWRJd1FZTUJhQUZOUldHTUNKT09nT1dJUVl5WFppdjZ1N3haQytNQklHQTFVZEV3RUIvd1FJTUFZQkFmOENBUUF3RGdZRFZSMFBBUUgvQkFRREFnR0dNQW9HQ0NxR1NNNDlCQU1DQTBjQU1FUUNJR0VtN3drWktIdC9hdGI0TWRGblhXNnlybndNVVQydTEzNmdkdGwxMFk2aEFpQnVURnF2Vll0aDFyYnh6Q1AweFdaSG1RSzlrVnl4bjhHUGZYMjdFSXp6c3c9PSJdLCJraWQiOiJNSUdVTUlHT3BJR0xNSUdJTVFzd0NRWURWUVFHRXdKRVJURVBNQTBHQTFVRUJ3d0dRbVZ5YkdsdU1SMHdHd1lEVlFRS0RCUkNkVzVrWlhOa2NuVmphMlZ5WldrZ1IyMWlTREVSTUE4R0ExVUVDd3dJVkNCRFV5QkpSRVV4TmpBMEJnTlZCQU1NTFZOUVVrbE9SQ0JHZFc1clpTQkZWVVJKSUZkaGJHeGxkQ0JRY205MGIzUjVjR1VnU1hOemRXbHVaeUJEUVFJQkFnPT0iLCJ0eXAiOiJ2YytzZC1qd3QiLCJhbGciOiJFUzI1NiJ9.eyJ2Y3QiOiJEUklWSU5HX0xJQ0VOQ0UiLCJfc2RfYWxnIjoic2hhLTI1NiIsImlzcyI6Imh0dHBzOi8vZXhhbXBsZS5jb20iLCJjbmYiOnsiandrIjp7Imt0eSI6IkVDIiwiY3J2IjoiUC0yNTYiLCJraWQiOiJITmt1dkQzZjEzM3BvbmRkSXJmWG5mcUNFOE9VQUcwa3BTSmR5c1BWTFFNIiwieCI6IlQ1Vlh2LVFKZjM4QW5YZDk2cXEtajZmY0lXdzV2Y016ajVJZUVhTEJvakkiLCJ5Ijoicmp3SDdCOUZlV3NVaFlEZk1qWng1QmFhS2pVQllnU21Nb0EzOEt2SFpEayJ9fSwiaWF0IjoxNzI0ODY4NDM5fQ.PxjYlyQJYu5tYIwOu-VPsIBFXB1z-WI7_QSRs8mPWeLlPfJ8POs23vZtrcBD-lXFQm38z4QRG9zw_yKYF0qDLw~',
+      'eyJ4NWMiOlsiTUlJQ2REQ0NBaHVnQXdJQkFnSUJBakFLQmdncWhrak9QUVFEQWpDQmlERUxNQWtHQTFVRUJoTUNSRVV4RHpBTkJnTlZCQWNNQmtKbGNteHBiakVkTUJzR0ExVUVDZ3dVUW5WdVpHVnpaSEoxWTJ0bGNtVnBJRWR0WWtneEVUQVBCZ05WQkFzTUNGUWdRMU1nU1VSRk1UWXdOQVlEVlFRRERDMVRVRkpKVGtRZ1JuVnVhMlVnUlZWRVNTQlhZV3hzWlhRZ1VISnZkRzkwZVhCbElFbHpjM1ZwYm1jZ1EwRXdIaGNOTWpRd05UTXhNRGd4TXpFM1doY05NalV3TnpBMU1EZ3hNekUzV2pCc01Rc3dDUVlEVlFRR0V3SkVSVEVkTUJzR0ExVUVDZ3dVUW5WdVpHVnpaSEoxWTJ0bGNtVnBJRWR0WWtneENqQUlCZ05WQkFzTUFVa3hNakF3QmdOVkJBTU1LVk5RVWtsT1JDQkdkVzVyWlNCRlZVUkpJRmRoYkd4bGRDQlFjbTkwYjNSNWNHVWdTWE56ZFdWeU1Ga3dFd1lIS29aSXpqMENBUVlJS29aSXpqMERBUWNEUWdBRU9GQnE0WU1LZzR3NWZUaWZzeXR3QnVKZi83RTdWaFJQWGlObTUyUzNxMUVUSWdCZFh5REsza1Z4R3hnZUhQaXZMUDN1dU12UzZpREVjN3FNeG12ZHVLT0JrRENCalRBZEJnTlZIUTRFRmdRVWlQaENrTEVyRFhQTFcyL0owV1ZlZ2h5dyttSXdEQVlEVlIwVEFRSC9CQUl3QURBT0JnTlZIUThCQWY4RUJBTUNCNEF3TFFZRFZSMFJCQ1l3SklJaVpHVnRieTV3YVdRdGFYTnpkV1Z5TG1KMWJtUmxjMlJ5ZFdOclpYSmxhUzVrWlRBZkJnTlZIU01FR0RBV2dCVFVWaGpBaVRqb0RsaUVHTWwyWXIrcnU4V1F2akFLQmdncWhrak9QUVFEQWdOSEFEQkVBaUFiZjVUemtjUXpoZldvSW95aTFWTjdkOEk5QnNGS20xTVdsdVJwaDJieUdRSWdLWWtkck5mMnhYUGpWU2JqVy9VLzVTNXZBRUM1WHhjT2FudXNPQnJvQmJVPSIsIk1JSUNlVENDQWlDZ0F3SUJBZ0lVQjVFOVFWWnRtVVljRHRDaktCL0gzVlF2NzJnd0NnWUlLb1pJemowRUF3SXdnWWd4Q3pBSkJnTlZCQVlUQWtSRk1ROHdEUVlEVlFRSERBWkNaWEpzYVc0eEhUQWJCZ05WQkFvTUZFSjFibVJsYzJSeWRXTnJaWEpsYVNCSGJXSklNUkV3RHdZRFZRUUxEQWhVSUVOVElFbEVSVEUyTURRR0ExVUVBd3d0VTFCU1NVNUVJRVoxYm10bElFVlZSRWtnVjJGc2JHVjBJRkJ5YjNSdmRIbHdaU0JKYzNOMWFXNW5JRU5CTUI0WERUSTBNRFV6TVRBMk5EZ3dPVm9YRFRNME1EVXlPVEEyTkRnd09Wb3dnWWd4Q3pBSkJnTlZCQVlUQWtSRk1ROHdEUVlEVlFRSERBWkNaWEpzYVc0eEhUQWJCZ05WQkFvTUZFSjFibVJsYzJSeWRXTnJaWEpsYVNCSGJXSklNUkV3RHdZRFZRUUxEQWhVSUVOVElFbEVSVEUyTURRR0ExVUVBd3d0VTFCU1NVNUVJRVoxYm10bElFVlZSRWtnVjJGc2JHVjBJRkJ5YjNSdmRIbHdaU0JKYzNOMWFXNW5JRU5CTUZrd0V3WUhLb1pJemowQ0FRWUlLb1pJemowREFRY0RRZ0FFWUd6ZHdGRG5jNytLbjVpYkF2Q09NOGtlNzdWUXhxZk1jd1pMOElhSUErV0NST2NDZm1ZL2dpSDkycU1ydTVwL2t5T2l2RTBSQy9JYmRNT052RG9VeWFObU1HUXdIUVlEVlIwT0JCWUVGTlJXR01DSk9PZ09XSVFZeVhaaXY2dTd4WkMrTUI4R0ExVWRJd1FZTUJhQUZOUldHTUNKT09nT1dJUVl5WFppdjZ1N3haQytNQklHQTFVZEV3RUIvd1FJTUFZQkFmOENBUUF3RGdZRFZSMFBBUUgvQkFRREFnR0dNQW9HQ0NxR1NNNDlCQU1DQTBjQU1FUUNJR0VtN3drWktIdC9hdGI0TWRGblhXNnlybndNVVQydTEzNmdkdGwxMFk2aEFpQnVURnF2Vll0aDFyYnh6Q1AweFdaSG1RSzlrVnl4bjhHUGZYMjdFSXp6c3c9PSJdLCJraWQiOiJNSUdVTUlHT3BJR0xNSUdJTVFzd0NRWURWUVFHRXdKRVJURVBNQTBHQTFVRUJ3d0dRbVZ5YkdsdU1SMHdHd1lEVlFRS0RCUkNkVzVrWlhOa2NuVmphMlZ5WldrZ1IyMWlTREVSTUE4R0ExVUVDd3dJVkNCRFV5QkpSRVV4TmpBMEJnTlZCQU1NTFZOUVVrbE9SQ0JHZFc1clpTQkZWVVJKSUZkaGJHeGxkQ0JRY205MGIzUjVjR1VnU1hOemRXbHVaeUJEUVFJQkFnPT0iLCJ0eXAiOiJ2YytzZC1qd3QiLCJhbGciOiJFUzI1NiJ9.eyJ2Y3QiOiJSRVNJREVOQ0VfUEVSTUlUIiwiX3NkX2FsZyI6InNoYS0yNTYiLCJpc3MiOiJodHRwczovL2V4YW1wbGUuY29tIiwiY25mIjp7Imp3ayI6eyJrdHkiOiJFQyIsImNydiI6IlAtMjU2Iiwia2lkIjoiSE5rdXZEM2YxMzNwb25kZElyZlhuZnFDRThPVUFHMGtwU0pkeXNQVkxRTSIsIngiOiJUNVZYdi1RSmYzOEFuWGQ5NnFxLWo2ZmNJV3c1dmNNemo1SWVFYUxCb2pJIiwieSI6InJqd0g3QjlGZVdzVWhZRGZNalp4NUJhYUtqVUJZZ1NtTW9BMzhLdkhaRGsifX0sImlhdCI6MTcyNDg2ODQzOX0.PxjYlyQJYu5tYIwOu-VPsIBFXB1z-WI7_QSRs8mPWeLlPfJ8POs23vZtrcBD-lXFQm38z4QRG9zw_yKYF0qDLw~',
+    ]
+    const pd = {
+      id: 'OverAgeCheck',
+      purpose: 'Age check',
+      input_descriptors: [
+        {
+          name: 'Residence permit date of birth and photo',
+          id: 'ResidencePermit',
+          constraints: {
+            limit_disclosure: 'required',
+            fields: [
+              {
+                path: ['$.vc.type.*', '$.vct', '$.type'],
+                filter: {
+                  type: 'string',
+                  const: 'RESIDENCE_PERMIT'
+                }
+              }
+            ]
+          }
+        },
+        {
+          name: 'ID date of birth and photo',
+          id: 'IDDoB',
+          constraints: {
+            limit_disclosure: 'required',
+            fields: [
+              {
+                path: ['$.vc.type.*', '$.vct', '$.type'],
+                filter: {
+                  type: 'string',
+                  const: 'ID'
+                }
+              }
+            ]
+          }
+        },
+        {
+          name: 'Driving licence date of birth and photo',
+          id: 'DrivingLicenceDoB',
+          constraints: {
+            limit_disclosure: 'required',
+            fields: [
+              {
+                path: ['$.vc.type.*', '$.vct', '$.type'],
+                filter: {
+                  type: 'string',
+                  const: 'DRIVING_LICENCE'
+                }
+              }
+            ]
+          }
+        }
+      ]
+    } satisfies IPresentationDefinition
+    const pex: PEX = new PEX({ hasher });
+
+    const result = pex.selectFrom(pd, sdJwtVcs);
+
+    expect(result.matches).toEqual([{
+      "name": "Residence permit date of birth and photo",
+      "rule": "all",
+      "vc_path": [
+        "$.verifiableCredential[0]"
+      ],
+      "type": "InputDescriptor",
+      "id": "ResidencePermit"
+    },
+    {
+      "name": "ID date of birth and photo",
+      "rule": "all",
+      "vc_path": [
+        "$.verifiableCredential[1]"
+      ],
+      "type": "InputDescriptor",
+      "id": "IDDoB"
+    },
+    {
+      "name": "Driving licence date of birth and photo",
+      "rule": "all",
+      "vc_path": [
+        "$.verifiableCredential[2]"
+      ],
+      "type": "InputDescriptor",
+      "id": "DrivingLicenceDoB"
+    }])
+
+
+  })
+
+  it('selectFrom adds index of submission requirement as id and type of match when using submission_requirements', () => {
+    const sdJwtVcs = [
+      'eyJ4NWMiOlsiTUlJQ2REQ0NBaHVnQXdJQkFnSUJBakFLQmdncWhrak9QUVFEQWpDQmlERUxNQWtHQTFVRUJoTUNSRVV4RHpBTkJnTlZCQWNNQmtKbGNteHBiakVkTUJzR0ExVUVDZ3dVUW5WdVpHVnpaSEoxWTJ0bGNtVnBJRWR0WWtneEVUQVBCZ05WQkFzTUNGUWdRMU1nU1VSRk1UWXdOQVlEVlFRRERDMVRVRkpKVGtRZ1JuVnVhMlVnUlZWRVNTQlhZV3hzWlhRZ1VISnZkRzkwZVhCbElFbHpjM1ZwYm1jZ1EwRXdIaGNOTWpRd05UTXhNRGd4TXpFM1doY05NalV3TnpBMU1EZ3hNekUzV2pCc01Rc3dDUVlEVlFRR0V3SkVSVEVkTUJzR0ExVUVDZ3dVUW5WdVpHVnpaSEoxWTJ0bGNtVnBJRWR0WWtneENqQUlCZ05WQkFzTUFVa3hNakF3QmdOVkJBTU1LVk5RVWtsT1JDQkdkVzVyWlNCRlZVUkpJRmRoYkd4bGRDQlFjbTkwYjNSNWNHVWdTWE56ZFdWeU1Ga3dFd1lIS29aSXpqMENBUVlJS29aSXpqMERBUWNEUWdBRU9GQnE0WU1LZzR3NWZUaWZzeXR3QnVKZi83RTdWaFJQWGlObTUyUzNxMUVUSWdCZFh5REsza1Z4R3hnZUhQaXZMUDN1dU12UzZpREVjN3FNeG12ZHVLT0JrRENCalRBZEJnTlZIUTRFRmdRVWlQaENrTEVyRFhQTFcyL0owV1ZlZ2h5dyttSXdEQVlEVlIwVEFRSC9CQUl3QURBT0JnTlZIUThCQWY4RUJBTUNCNEF3TFFZRFZSMFJCQ1l3SklJaVpHVnRieTV3YVdRdGFYTnpkV1Z5TG1KMWJtUmxjMlJ5ZFdOclpYSmxhUzVrWlRBZkJnTlZIU01FR0RBV2dCVFVWaGpBaVRqb0RsaUVHTWwyWXIrcnU4V1F2akFLQmdncWhrak9QUVFEQWdOSEFEQkVBaUFiZjVUemtjUXpoZldvSW95aTFWTjdkOEk5QnNGS20xTVdsdVJwaDJieUdRSWdLWWtkck5mMnhYUGpWU2JqVy9VLzVTNXZBRUM1WHhjT2FudXNPQnJvQmJVPSIsIk1JSUNlVENDQWlDZ0F3SUJBZ0lVQjVFOVFWWnRtVVljRHRDaktCL0gzVlF2NzJnd0NnWUlLb1pJemowRUF3SXdnWWd4Q3pBSkJnTlZCQVlUQWtSRk1ROHdEUVlEVlFRSERBWkNaWEpzYVc0eEhUQWJCZ05WQkFvTUZFSjFibVJsYzJSeWRXTnJaWEpsYVNCSGJXSklNUkV3RHdZRFZRUUxEQWhVSUVOVElFbEVSVEUyTURRR0ExVUVBd3d0VTFCU1NVNUVJRVoxYm10bElFVlZSRWtnVjJGc2JHVjBJRkJ5YjNSdmRIbHdaU0JKYzNOMWFXNW5JRU5CTUI0WERUSTBNRFV6TVRBMk5EZ3dPVm9YRFRNME1EVXlPVEEyTkRnd09Wb3dnWWd4Q3pBSkJnTlZCQVlUQWtSRk1ROHdEUVlEVlFRSERBWkNaWEpzYVc0eEhUQWJCZ05WQkFvTUZFSjFibVJsYzJSeWRXTnJaWEpsYVNCSGJXSklNUkV3RHdZRFZRUUxEQWhVSUVOVElFbEVSVEUyTURRR0ExVUVBd3d0VTFCU1NVNUVJRVoxYm10bElFVlZSRWtnVjJGc2JHVjBJRkJ5YjNSdmRIbHdaU0JKYzNOMWFXNW5JRU5CTUZrd0V3WUhLb1pJemowQ0FRWUlLb1pJemowREFRY0RRZ0FFWUd6ZHdGRG5jNytLbjVpYkF2Q09NOGtlNzdWUXhxZk1jd1pMOElhSUErV0NST2NDZm1ZL2dpSDkycU1ydTVwL2t5T2l2RTBSQy9JYmRNT052RG9VeWFObU1HUXdIUVlEVlIwT0JCWUVGTlJXR01DSk9PZ09XSVFZeVhaaXY2dTd4WkMrTUI4R0ExVWRJd1FZTUJhQUZOUldHTUNKT09nT1dJUVl5WFppdjZ1N3haQytNQklHQTFVZEV3RUIvd1FJTUFZQkFmOENBUUF3RGdZRFZSMFBBUUgvQkFRREFnR0dNQW9HQ0NxR1NNNDlCQU1DQTBjQU1FUUNJR0VtN3drWktIdC9hdGI0TWRGblhXNnlybndNVVQydTEzNmdkdGwxMFk2aEFpQnVURnF2Vll0aDFyYnh6Q1AweFdaSG1RSzlrVnl4bjhHUGZYMjdFSXp6c3c9PSJdLCJraWQiOiJNSUdVTUlHT3BJR0xNSUdJTVFzd0NRWURWUVFHRXdKRVJURVBNQTBHQTFVRUJ3d0dRbVZ5YkdsdU1SMHdHd1lEVlFRS0RCUkNkVzVrWlhOa2NuVmphMlZ5WldrZ1IyMWlTREVSTUE4R0ExVUVDd3dJVkNCRFV5QkpSRVV4TmpBMEJnTlZCQU1NTFZOUVVrbE9SQ0JHZFc1clpTQkZWVVJKSUZkaGJHeGxkQ0JRY205MGIzUjVjR1VnU1hOemRXbHVaeUJEUVFJQkFnPT0iLCJ0eXAiOiJ2YytzZC1qd3QiLCJhbGciOiJFUzI1NiJ9.eyJ2Y3QiOiJJRCIsIl9zZF9hbGciOiJzaGEtMjU2IiwiaXNzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbSIsImNuZiI6eyJqd2siOnsia3R5IjoiRUMiLCJjcnYiOiJQLTI1NiIsImtpZCI6IkhOa3V2RDNmMTMzcG9uZGRJcmZYbmZxQ0U4T1VBRzBrcFNKZHlzUFZMUU0iLCJ4IjoiVDVWWHYtUUpmMzhBblhkOTZxcS1qNmZjSVd3NXZjTXpqNUllRWFMQm9qSSIsInkiOiJyandIN0I5RmVXc1VoWURmTWpaeDVCYWFLalVCWWdTbU1vQTM4S3ZIWkRrIn19LCJpYXQiOjE3MjQ4Njg0Mzl9.PxjYlyQJYu5tYIwOu-VPsIBFXB1z-WI7_QSRs8mPWeLlPfJ8POs23vZtrcBD-lXFQm38z4QRG9zw_yKYF0qDLw~',
+      'eyJ4NWMiOlsiTUlJQ2REQ0NBaHVnQXdJQkFnSUJBakFLQmdncWhrak9QUVFEQWpDQmlERUxNQWtHQTFVRUJoTUNSRVV4RHpBTkJnTlZCQWNNQmtKbGNteHBiakVkTUJzR0ExVUVDZ3dVUW5WdVpHVnpaSEoxWTJ0bGNtVnBJRWR0WWtneEVUQVBCZ05WQkFzTUNGUWdRMU1nU1VSRk1UWXdOQVlEVlFRRERDMVRVRkpKVGtRZ1JuVnVhMlVnUlZWRVNTQlhZV3hzWlhRZ1VISnZkRzkwZVhCbElFbHpjM1ZwYm1jZ1EwRXdIaGNOTWpRd05UTXhNRGd4TXpFM1doY05NalV3TnpBMU1EZ3hNekUzV2pCc01Rc3dDUVlEVlFRR0V3SkVSVEVkTUJzR0ExVUVDZ3dVUW5WdVpHVnpaSEoxWTJ0bGNtVnBJRWR0WWtneENqQUlCZ05WQkFzTUFVa3hNakF3QmdOVkJBTU1LVk5RVWtsT1JDQkdkVzVyWlNCRlZVUkpJRmRoYkd4bGRDQlFjbTkwYjNSNWNHVWdTWE56ZFdWeU1Ga3dFd1lIS29aSXpqMENBUVlJS29aSXpqMERBUWNEUWdBRU9GQnE0WU1LZzR3NWZUaWZzeXR3QnVKZi83RTdWaFJQWGlObTUyUzNxMUVUSWdCZFh5REsza1Z4R3hnZUhQaXZMUDN1dU12UzZpREVjN3FNeG12ZHVLT0JrRENCalRBZEJnTlZIUTRFRmdRVWlQaENrTEVyRFhQTFcyL0owV1ZlZ2h5dyttSXdEQVlEVlIwVEFRSC9CQUl3QURBT0JnTlZIUThCQWY4RUJBTUNCNEF3TFFZRFZSMFJCQ1l3SklJaVpHVnRieTV3YVdRdGFYTnpkV1Z5TG1KMWJtUmxjMlJ5ZFdOclpYSmxhUzVrWlRBZkJnTlZIU01FR0RBV2dCVFVWaGpBaVRqb0RsaUVHTWwyWXIrcnU4V1F2akFLQmdncWhrak9QUVFEQWdOSEFEQkVBaUFiZjVUemtjUXpoZldvSW95aTFWTjdkOEk5QnNGS20xTVdsdVJwaDJieUdRSWdLWWtkck5mMnhYUGpWU2JqVy9VLzVTNXZBRUM1WHhjT2FudXNPQnJvQmJVPSIsIk1JSUNlVENDQWlDZ0F3SUJBZ0lVQjVFOVFWWnRtVVljRHRDaktCL0gzVlF2NzJnd0NnWUlLb1pJemowRUF3SXdnWWd4Q3pBSkJnTlZCQVlUQWtSRk1ROHdEUVlEVlFRSERBWkNaWEpzYVc0eEhUQWJCZ05WQkFvTUZFSjFibVJsYzJSeWRXTnJaWEpsYVNCSGJXSklNUkV3RHdZRFZRUUxEQWhVSUVOVElFbEVSVEUyTURRR0ExVUVBd3d0VTFCU1NVNUVJRVoxYm10bElFVlZSRWtnVjJGc2JHVjBJRkJ5YjNSdmRIbHdaU0JKYzNOMWFXNW5JRU5CTUI0WERUSTBNRFV6TVRBMk5EZ3dPVm9YRFRNME1EVXlPVEEyTkRnd09Wb3dnWWd4Q3pBSkJnTlZCQVlUQWtSRk1ROHdEUVlEVlFRSERBWkNaWEpzYVc0eEhUQWJCZ05WQkFvTUZFSjFibVJsYzJSeWRXTnJaWEpsYVNCSGJXSklNUkV3RHdZRFZRUUxEQWhVSUVOVElFbEVSVEUyTURRR0ExVUVBd3d0VTFCU1NVNUVJRVoxYm10bElFVlZSRWtnVjJGc2JHVjBJRkJ5YjNSdmRIbHdaU0JKYzNOMWFXNW5JRU5CTUZrd0V3WUhLb1pJemowQ0FRWUlLb1pJemowREFRY0RRZ0FFWUd6ZHdGRG5jNytLbjVpYkF2Q09NOGtlNzdWUXhxZk1jd1pMOElhSUErV0NST2NDZm1ZL2dpSDkycU1ydTVwL2t5T2l2RTBSQy9JYmRNT052RG9VeWFObU1HUXdIUVlEVlIwT0JCWUVGTlJXR01DSk9PZ09XSVFZeVhaaXY2dTd4WkMrTUI4R0ExVWRJd1FZTUJhQUZOUldHTUNKT09nT1dJUVl5WFppdjZ1N3haQytNQklHQTFVZEV3RUIvd1FJTUFZQkFmOENBUUF3RGdZRFZSMFBBUUgvQkFRREFnR0dNQW9HQ0NxR1NNNDlCQU1DQTBjQU1FUUNJR0VtN3drWktIdC9hdGI0TWRGblhXNnlybndNVVQydTEzNmdkdGwxMFk2aEFpQnVURnF2Vll0aDFyYnh6Q1AweFdaSG1RSzlrVnl4bjhHUGZYMjdFSXp6c3c9PSJdLCJraWQiOiJNSUdVTUlHT3BJR0xNSUdJTVFzd0NRWURWUVFHRXdKRVJURVBNQTBHQTFVRUJ3d0dRbVZ5YkdsdU1SMHdHd1lEVlFRS0RCUkNkVzVrWlhOa2NuVmphMlZ5WldrZ1IyMWlTREVSTUE4R0ExVUVDd3dJVkNCRFV5QkpSRVV4TmpBMEJnTlZCQU1NTFZOUVVrbE9SQ0JHZFc1clpTQkZWVVJKSUZkaGJHeGxkQ0JRY205MGIzUjVjR1VnU1hOemRXbHVaeUJEUVFJQkFnPT0iLCJ0eXAiOiJ2YytzZC1qd3QiLCJhbGciOiJFUzI1NiJ9.eyJ2Y3QiOiJEUklWSU5HX0xJQ0VOQ0UiLCJfc2RfYWxnIjoic2hhLTI1NiIsImlzcyI6Imh0dHBzOi8vZXhhbXBsZS5jb20iLCJjbmYiOnsiandrIjp7Imt0eSI6IkVDIiwiY3J2IjoiUC0yNTYiLCJraWQiOiJITmt1dkQzZjEzM3BvbmRkSXJmWG5mcUNFOE9VQUcwa3BTSmR5c1BWTFFNIiwieCI6IlQ1Vlh2LVFKZjM4QW5YZDk2cXEtajZmY0lXdzV2Y016ajVJZUVhTEJvakkiLCJ5Ijoicmp3SDdCOUZlV3NVaFlEZk1qWng1QmFhS2pVQllnU21Nb0EzOEt2SFpEayJ9fSwiaWF0IjoxNzI0ODY4NDM5fQ.PxjYlyQJYu5tYIwOu-VPsIBFXB1z-WI7_QSRs8mPWeLlPfJ8POs23vZtrcBD-lXFQm38z4QRG9zw_yKYF0qDLw~',
+      'eyJ4NWMiOlsiTUlJQ2REQ0NBaHVnQXdJQkFnSUJBakFLQmdncWhrak9QUVFEQWpDQmlERUxNQWtHQTFVRUJoTUNSRVV4RHpBTkJnTlZCQWNNQmtKbGNteHBiakVkTUJzR0ExVUVDZ3dVUW5WdVpHVnpaSEoxWTJ0bGNtVnBJRWR0WWtneEVUQVBCZ05WQkFzTUNGUWdRMU1nU1VSRk1UWXdOQVlEVlFRRERDMVRVRkpKVGtRZ1JuVnVhMlVnUlZWRVNTQlhZV3hzWlhRZ1VISnZkRzkwZVhCbElFbHpjM1ZwYm1jZ1EwRXdIaGNOTWpRd05UTXhNRGd4TXpFM1doY05NalV3TnpBMU1EZ3hNekUzV2pCc01Rc3dDUVlEVlFRR0V3SkVSVEVkTUJzR0ExVUVDZ3dVUW5WdVpHVnpaSEoxWTJ0bGNtVnBJRWR0WWtneENqQUlCZ05WQkFzTUFVa3hNakF3QmdOVkJBTU1LVk5RVWtsT1JDQkdkVzVyWlNCRlZVUkpJRmRoYkd4bGRDQlFjbTkwYjNSNWNHVWdTWE56ZFdWeU1Ga3dFd1lIS29aSXpqMENBUVlJS29aSXpqMERBUWNEUWdBRU9GQnE0WU1LZzR3NWZUaWZzeXR3QnVKZi83RTdWaFJQWGlObTUyUzNxMUVUSWdCZFh5REsza1Z4R3hnZUhQaXZMUDN1dU12UzZpREVjN3FNeG12ZHVLT0JrRENCalRBZEJnTlZIUTRFRmdRVWlQaENrTEVyRFhQTFcyL0owV1ZlZ2h5dyttSXdEQVlEVlIwVEFRSC9CQUl3QURBT0JnTlZIUThCQWY4RUJBTUNCNEF3TFFZRFZSMFJCQ1l3SklJaVpHVnRieTV3YVdRdGFYTnpkV1Z5TG1KMWJtUmxjMlJ5ZFdOclpYSmxhUzVrWlRBZkJnTlZIU01FR0RBV2dCVFVWaGpBaVRqb0RsaUVHTWwyWXIrcnU4V1F2akFLQmdncWhrak9QUVFEQWdOSEFEQkVBaUFiZjVUemtjUXpoZldvSW95aTFWTjdkOEk5QnNGS20xTVdsdVJwaDJieUdRSWdLWWtkck5mMnhYUGpWU2JqVy9VLzVTNXZBRUM1WHhjT2FudXNPQnJvQmJVPSIsIk1JSUNlVENDQWlDZ0F3SUJBZ0lVQjVFOVFWWnRtVVljRHRDaktCL0gzVlF2NzJnd0NnWUlLb1pJemowRUF3SXdnWWd4Q3pBSkJnTlZCQVlUQWtSRk1ROHdEUVlEVlFRSERBWkNaWEpzYVc0eEhUQWJCZ05WQkFvTUZFSjFibVJsYzJSeWRXTnJaWEpsYVNCSGJXSklNUkV3RHdZRFZRUUxEQWhVSUVOVElFbEVSVEUyTURRR0ExVUVBd3d0VTFCU1NVNUVJRVoxYm10bElFVlZSRWtnVjJGc2JHVjBJRkJ5YjNSdmRIbHdaU0JKYzNOMWFXNW5JRU5CTUI0WERUSTBNRFV6TVRBMk5EZ3dPVm9YRFRNME1EVXlPVEEyTkRnd09Wb3dnWWd4Q3pBSkJnTlZCQVlUQWtSRk1ROHdEUVlEVlFRSERBWkNaWEpzYVc0eEhUQWJCZ05WQkFvTUZFSjFibVJsYzJSeWRXTnJaWEpsYVNCSGJXSklNUkV3RHdZRFZRUUxEQWhVSUVOVElFbEVSVEUyTURRR0ExVUVBd3d0VTFCU1NVNUVJRVoxYm10bElFVlZSRWtnVjJGc2JHVjBJRkJ5YjNSdmRIbHdaU0JKYzNOMWFXNW5JRU5CTUZrd0V3WUhLb1pJemowQ0FRWUlLb1pJemowREFRY0RRZ0FFWUd6ZHdGRG5jNytLbjVpYkF2Q09NOGtlNzdWUXhxZk1jd1pMOElhSUErV0NST2NDZm1ZL2dpSDkycU1ydTVwL2t5T2l2RTBSQy9JYmRNT052RG9VeWFObU1HUXdIUVlEVlIwT0JCWUVGTlJXR01DSk9PZ09XSVFZeVhaaXY2dTd4WkMrTUI4R0ExVWRJd1FZTUJhQUZOUldHTUNKT09nT1dJUVl5WFppdjZ1N3haQytNQklHQTFVZEV3RUIvd1FJTUFZQkFmOENBUUF3RGdZRFZSMFBBUUgvQkFRREFnR0dNQW9HQ0NxR1NNNDlCQU1DQTBjQU1FUUNJR0VtN3drWktIdC9hdGI0TWRGblhXNnlybndNVVQydTEzNmdkdGwxMFk2aEFpQnVURnF2Vll0aDFyYnh6Q1AweFdaSG1RSzlrVnl4bjhHUGZYMjdFSXp6c3c9PSJdLCJraWQiOiJNSUdVTUlHT3BJR0xNSUdJTVFzd0NRWURWUVFHRXdKRVJURVBNQTBHQTFVRUJ3d0dRbVZ5YkdsdU1SMHdHd1lEVlFRS0RCUkNkVzVrWlhOa2NuVmphMlZ5WldrZ1IyMWlTREVSTUE4R0ExVUVDd3dJVkNCRFV5QkpSRVV4TmpBMEJnTlZCQU1NTFZOUVVrbE9SQ0JHZFc1clpTQkZWVVJKSUZkaGJHeGxkQ0JRY205MGIzUjVjR1VnU1hOemRXbHVaeUJEUVFJQkFnPT0iLCJ0eXAiOiJ2YytzZC1qd3QiLCJhbGciOiJFUzI1NiJ9.eyJ2Y3QiOiJSRVNJREVOQ0VfUEVSTUlUIiwiX3NkX2FsZyI6InNoYS0yNTYiLCJpc3MiOiJodHRwczovL2V4YW1wbGUuY29tIiwiY25mIjp7Imp3ayI6eyJrdHkiOiJFQyIsImNydiI6IlAtMjU2Iiwia2lkIjoiSE5rdXZEM2YxMzNwb25kZElyZlhuZnFDRThPVUFHMGtwU0pkeXNQVkxRTSIsIngiOiJUNVZYdi1RSmYzOEFuWGQ5NnFxLWo2ZmNJV3c1dmNNemo1SWVFYUxCb2pJIiwieSI6InJqd0g3QjlGZVdzVWhZRGZNalp4NUJhYUtqVUJZZ1NtTW9BMzhLdkhaRGsifX0sImlhdCI6MTcyNDg2ODQzOX0.PxjYlyQJYu5tYIwOu-VPsIBFXB1z-WI7_QSRs8mPWeLlPfJ8POs23vZtrcBD-lXFQm38z4QRG9zw_yKYF0qDLw~',
+    ]
+    const pd = {
+      id: 'OverAgeCheck',
+      purpose: 'Age check',
+      submission_requirements: [
+        {
+          name: 'Proof of age and photo',
+          rule: 'pick',
+          count: 1,
+          from: 'validAgeCheckInputDescriptor'
+        },
+        {
+          name: 'Proof of other',
+          rule: 'pick',
+          count: 1,
+          from: 'validOtherCheck'
+        }
+      ],
+      input_descriptors: [
+        {
+          name: 'Residence permit date of birth and photo',
+          id: 'ResidencePermit',
+          group: ['validOtherCheck'],
+          constraints: {
+            limit_disclosure: 'required',
+            fields: [
+              {
+                path: ['$.vc.type.*', '$.vct', '$.type'],
+                filter: {
+                  type: 'string',
+                  const: 'RESIDENCE_PERMIT'
+                }
+              }
+            ]
+          }
+        },
+        {
+          name: 'ID date of birth and photo',
+          id: 'IDDoB',
+          group: ['validAgeCheckInputDescriptor', 'validOtherCheck'],
+          constraints: {
+            limit_disclosure: 'required',
+            fields: [
+              {
+                path: ['$.vc.type.*', '$.vct', '$.type'],
+                filter: {
+                  type: 'string',
+                  const: 'ID'
+                }
+              }
+            ]
+          }
+        },
+        {
+          name: 'Driving licence date of birth and photo',
+          id: 'DrivingLicenceDoB',
+          group: ['validAgeCheckInputDescriptor'],
+          constraints: {
+            limit_disclosure: 'required',
+            fields: [
+              {
+                path: ['$.vc.type.*', '$.vct', '$.type'],
+                filter: {
+                  type: 'string',
+                  const: 'DRIVING_LICENCE'
+                }
+              }
+            ]
+          }
+        }
+      ]
+    } satisfies IPresentationDefinition
+    const pex: PEX = new PEX({ hasher });
+
+    const result = pex.selectFrom(pd, sdJwtVcs);
+
+    expect(result.matches).toEqual([{
+      "rule": "pick",
+      "vc_path": [
+        "$.verifiableCredential[0]",
+        "$.verifiableCredential[1]"
+      ],
+      "name": "Proof of age and photo",
+      "type": "SubmissionRequirement",
+      "id": 0,
+      "from": "validAgeCheckInputDescriptor",
+      "count": 1
+    },
+    {
+      "rule": "pick",
+      "vc_path": [
+        "$.verifiableCredential[2]",
+        "$.verifiableCredential[0]"
+      ],
+      "name": "Proof of other",
+      "type": "SubmissionRequirement",
+      "id": 1,
+      "from": "validOtherCheck",
+      "count": 1
+    }])
+
+
+  })
 
   it('should map the sd-jwt credential correctly with the indices of selecFrom result', () => {
     const sdJwt: OriginalVerifiableCredential =

--- a/test/PEXv2.spec.ts
+++ b/test/PEXv2.spec.ts
@@ -312,7 +312,7 @@ describe('evaluate', () => {
     });
     expect(result!.errors!.length).toEqual(0);
     expect(JSON.stringify(result!.matches)).toBe(
-      JSON.stringify([{ name: 'Verify Valid License', rule: 'all', vc_path: ['$.verifiableCredential[0]'] }]),
+      JSON.stringify([{ name: 'Verify Valid License', rule: 'all', vc_path: ['$.verifiableCredential[0]'], "type": "InputDescriptor", "id": "drivers_license_information" }]),
     );
     expect(result!.areRequiredCredentialsPresent).toBe('info');
   });

--- a/test/PEXv2.spec.ts
+++ b/test/PEXv2.spec.ts
@@ -312,7 +312,15 @@ describe('evaluate', () => {
     });
     expect(result!.errors!.length).toEqual(0);
     expect(JSON.stringify(result!.matches)).toBe(
-      JSON.stringify([{ name: 'Verify Valid License', rule: 'all', vc_path: ['$.verifiableCredential[0]'], "type": "InputDescriptor", "id": "drivers_license_information" }]),
+      JSON.stringify([
+        {
+          name: 'Verify Valid License',
+          rule: 'all',
+          vc_path: ['$.verifiableCredential[0]'],
+          type: 'InputDescriptor',
+          id: 'drivers_license_information',
+        },
+      ]),
     );
     expect(result!.areRequiredCredentialsPresent).toBe('info');
   });

--- a/test/SdJwt.spec.ts
+++ b/test/SdJwt.spec.ts
@@ -4,8 +4,8 @@ import { PresentationDefinitionV2 } from '@sphereon/pex-models';
 import { SdJwtDecodedVerifiableCredential } from '@sphereon/ssi-types';
 
 import { PEX, PresentationSubmissionLocation, SdJwtDecodedVerifiableCredentialWithKbJwtInput, Status, Validated } from '../lib';
-import { calculateSdHash } from '../lib/utils';
 import { SubmissionRequirementMatchType } from '../lib/evaluation/core';
+import { calculateSdHash } from '../lib/utils';
 
 export const hasher = (data: string) => createHash('sha256').update(data).digest();
 
@@ -179,7 +179,15 @@ describe('evaluate', () => {
   it('selectFrom with vc+sd-jwt format compact', () => {
     const result = pex.selectFrom(getPresentationDefinitionV2(), [decodedSdJwtVc.compactSdJwtVc]);
     expect(result.errors?.length).toEqual(0);
-    expect(result.matches).toEqual([{ name: 'Washington State Business License', rule: 'all', vc_path: ['$.verifiableCredential[0]'], type: SubmissionRequirementMatchType.InputDescriptor, id: 'wa_driver_license' }]);
+    expect(result.matches).toEqual([
+      {
+        name: 'Washington State Business License',
+        rule: 'all',
+        vc_path: ['$.verifiableCredential[0]'],
+        type: SubmissionRequirementMatchType.InputDescriptor,
+        id: 'wa_driver_license',
+      },
+    ]);
     expect(result.areRequiredCredentialsPresent).toBe('info');
 
     // Should have already applied selective disclosure on the SD-JWT
@@ -189,7 +197,15 @@ describe('evaluate', () => {
   it('selectFrom with vc+sd-jwt format already decoded', () => {
     const result = pex.selectFrom(getPresentationDefinitionV2(), [decodedSdJwtVc]);
     expect(result.errors?.length).toEqual(0);
-    expect(result.matches).toEqual([{ name: 'Washington State Business License', rule: 'all', vc_path: ['$.verifiableCredential[0]'], type: SubmissionRequirementMatchType.InputDescriptor, id: 'wa_driver_license' }]);
+    expect(result.matches).toEqual([
+      {
+        name: 'Washington State Business License',
+        rule: 'all',
+        vc_path: ['$.verifiableCredential[0]'],
+        type: SubmissionRequirementMatchType.InputDescriptor,
+        id: 'wa_driver_license',
+      },
+    ]);
     expect(result.areRequiredCredentialsPresent).toBe('info');
 
     // Should have already applied selective disclosure on the SD-JWT

--- a/test/SdJwt.spec.ts
+++ b/test/SdJwt.spec.ts
@@ -5,6 +5,7 @@ import { SdJwtDecodedVerifiableCredential } from '@sphereon/ssi-types';
 
 import { PEX, PresentationSubmissionLocation, SdJwtDecodedVerifiableCredentialWithKbJwtInput, Status, Validated } from '../lib';
 import { calculateSdHash } from '../lib/utils';
+import { SubmissionRequirementMatchType } from '../lib/evaluation/core';
 
 export const hasher = (data: string) => createHash('sha256').update(data).digest();
 
@@ -178,7 +179,7 @@ describe('evaluate', () => {
   it('selectFrom with vc+sd-jwt format compact', () => {
     const result = pex.selectFrom(getPresentationDefinitionV2(), [decodedSdJwtVc.compactSdJwtVc]);
     expect(result.errors?.length).toEqual(0);
-    expect(result.matches).toEqual([{ name: 'Washington State Business License', rule: 'all', vc_path: ['$.verifiableCredential[0]'] }]);
+    expect(result.matches).toEqual([{ name: 'Washington State Business License', rule: 'all', vc_path: ['$.verifiableCredential[0]'], type: SubmissionRequirementMatchType.InputDescriptor, id: 'wa_driver_license' }]);
     expect(result.areRequiredCredentialsPresent).toBe('info');
 
     // Should have already applied selective disclosure on the SD-JWT
@@ -188,7 +189,7 @@ describe('evaluate', () => {
   it('selectFrom with vc+sd-jwt format already decoded', () => {
     const result = pex.selectFrom(getPresentationDefinitionV2(), [decodedSdJwtVc]);
     expect(result.errors?.length).toEqual(0);
-    expect(result.matches).toEqual([{ name: 'Washington State Business License', rule: 'all', vc_path: ['$.verifiableCredential[0]'] }]);
+    expect(result.matches).toEqual([{ name: 'Washington State Business License', rule: 'all', vc_path: ['$.verifiableCredential[0]'], type: SubmissionRequirementMatchType.InputDescriptor, id: 'wa_driver_license' }]);
     expect(result.areRequiredCredentialsPresent).toBe('info');
 
     // Should have already applied selective disclosure on the SD-JWT

--- a/test/evaluation/EvaluationClientWrapperData.ts
+++ b/test/evaluation/EvaluationClientWrapperData.ts
@@ -3,6 +3,7 @@ import { IVerifiableCredential } from '@sphereon/ssi-types';
 
 import { HandlerCheckResult, SelectResults, Status } from '../../lib';
 import PexMessages from '../../lib/types/Messages';
+import { SubmissionRequirementMatchType } from '../../lib/evaluation/core';
 
 export class EvaluationClientWrapperData {
   public getHolderDID(): string[] {
@@ -197,6 +198,8 @@ export class EvaluationClientWrapperData {
           name: 'test',
           rule: Rules.All,
           vc_path: ['$.verifiableCredential[0]'],
+          id: 'Educational transcripts',
+          type: SubmissionRequirementMatchType.InputDescriptor
         },
       ],
     };

--- a/test/evaluation/EvaluationClientWrapperData.ts
+++ b/test/evaluation/EvaluationClientWrapperData.ts
@@ -2,8 +2,8 @@ import { PresentationSubmission, Rules } from '@sphereon/pex-models';
 import { IVerifiableCredential } from '@sphereon/ssi-types';
 
 import { HandlerCheckResult, SelectResults, Status } from '../../lib';
-import PexMessages from '../../lib/types/Messages';
 import { SubmissionRequirementMatchType } from '../../lib/evaluation/core';
+import PexMessages from '../../lib/types/Messages';
 
 export class EvaluationClientWrapperData {
   public getHolderDID(): string[] {
@@ -199,7 +199,7 @@ export class EvaluationClientWrapperData {
           rule: Rules.All,
           vc_path: ['$.verifiableCredential[0]'],
           id: 'Educational transcripts',
-          type: SubmissionRequirementMatchType.InputDescriptor
+          type: SubmissionRequirementMatchType.InputDescriptor,
         },
       ],
     };

--- a/test/evaluation/check-scenario-1.spec.ts
+++ b/test/evaluation/check-scenario-1.spec.ts
@@ -4,6 +4,7 @@ import { IPresentation, IVerifiableCredential } from '@sphereon/ssi-types';
 import { PEX } from '../../lib';
 
 import { Wallet } from './core/Wallet';
+import { SubmissionRequirementMatchType } from '../../lib/evaluation/core';
 
 const LIMIT_DISCLOSURE_SIGNATURE_SUITES = ['BbsBlsSignatureProof2020'];
 
@@ -203,8 +204,8 @@ describe('1st scenario', () => {
     });
     expect(selectFromResult.matches?.length).toEqual(2);
     expect(selectFromResult.matches).toEqual([
-      { rule: 'all', vc_path: ['$.verifiableCredential[0]'], name: 'e73646de-43e2-4d72-ba4f-090d01c11eac' },
-      { rule: 'all', vc_path: ['$.verifiableCredential[0]'], name: '867bfe7a-5b91-46b2-9ba4-70028b8d9cc8' },
+      { rule: 'all', vc_path: ['$.verifiableCredential[0]'], name: 'e73646de-43e2-4d72-ba4f-090d01c11eac', type: SubmissionRequirementMatchType.InputDescriptor, id: 'e73646de-43e2-4d72-ba4f-090d01c11eac' },
+      { rule: 'all', vc_path: ['$.verifiableCredential[0]'], name: '867bfe7a-5b91-46b2-9ba4-70028b8d9cc8', type: SubmissionRequirementMatchType.InputDescriptor, id: '867bfe7a-5b91-46b2-9ba4-70028b8d9cc8' },
     ]);
     expect(selectFromResult.verifiableCredential?.length).toEqual(1);
 

--- a/test/evaluation/check-scenario-1.spec.ts
+++ b/test/evaluation/check-scenario-1.spec.ts
@@ -2,9 +2,9 @@ import { PresentationDefinitionV1 as PdV1 } from '@sphereon/pex-models';
 import { IPresentation, IVerifiableCredential } from '@sphereon/ssi-types';
 
 import { PEX } from '../../lib';
+import { SubmissionRequirementMatchType } from '../../lib/evaluation/core';
 
 import { Wallet } from './core/Wallet';
-import { SubmissionRequirementMatchType } from '../../lib/evaluation/core';
 
 const LIMIT_DISCLOSURE_SIGNATURE_SUITES = ['BbsBlsSignatureProof2020'];
 
@@ -204,8 +204,20 @@ describe('1st scenario', () => {
     });
     expect(selectFromResult.matches?.length).toEqual(2);
     expect(selectFromResult.matches).toEqual([
-      { rule: 'all', vc_path: ['$.verifiableCredential[0]'], name: 'e73646de-43e2-4d72-ba4f-090d01c11eac', type: SubmissionRequirementMatchType.InputDescriptor, id: 'e73646de-43e2-4d72-ba4f-090d01c11eac' },
-      { rule: 'all', vc_path: ['$.verifiableCredential[0]'], name: '867bfe7a-5b91-46b2-9ba4-70028b8d9cc8', type: SubmissionRequirementMatchType.InputDescriptor, id: '867bfe7a-5b91-46b2-9ba4-70028b8d9cc8' },
+      {
+        rule: 'all',
+        vc_path: ['$.verifiableCredential[0]'],
+        name: 'e73646de-43e2-4d72-ba4f-090d01c11eac',
+        type: SubmissionRequirementMatchType.InputDescriptor,
+        id: 'e73646de-43e2-4d72-ba4f-090d01c11eac',
+      },
+      {
+        rule: 'all',
+        vc_path: ['$.verifiableCredential[0]'],
+        name: '867bfe7a-5b91-46b2-9ba4-70028b8d9cc8',
+        type: SubmissionRequirementMatchType.InputDescriptor,
+        id: '867bfe7a-5b91-46b2-9ba4-70028b8d9cc8',
+      },
     ]);
     expect(selectFromResult.verifiableCredential?.length).toEqual(1);
 

--- a/test/evaluation/core/submissionRequirementMatch.spec.ts
+++ b/test/evaluation/core/submissionRequirementMatch.spec.ts
@@ -1,6 +1,7 @@
 import { Rules } from '@sphereon/pex-models';
 
 import { SubmissionRequirementMatch } from '../../../lib';
+import { SubmissionRequirementMatchType } from '../../../lib/evaluation/core';
 
 describe('submissionRequirementMatch', () => {
   it('should return ok constructor works correctly', function () {
@@ -9,6 +10,8 @@ describe('submissionRequirementMatch', () => {
       rule: Rules.All,
       vc_path: ['$.verifiableCredential[1]'],
       from: 'A',
+      id: 0,
+      type: SubmissionRequirementMatchType.SubmissionRequirement
     };
     expect(submissionRequirementMatch.from).toContain('A');
     expect(submissionRequirementMatch.rule).toBe(Rules.All);

--- a/test/evaluation/core/submissionRequirementMatch.spec.ts
+++ b/test/evaluation/core/submissionRequirementMatch.spec.ts
@@ -11,7 +11,7 @@ describe('submissionRequirementMatch', () => {
       vc_path: ['$.verifiableCredential[1]'],
       from: 'A',
       id: 0,
-      type: SubmissionRequirementMatchType.SubmissionRequirement
+      type: SubmissionRequirementMatchType.SubmissionRequirement,
     };
     expect(submissionRequirementMatch.from).toContain('A');
     expect(submissionRequirementMatch.rule).toBe(Rules.All);

--- a/test/evaluation/selectFrom.spec.ts
+++ b/test/evaluation/selectFrom.spec.ts
@@ -5,9 +5,9 @@ import { IVerifiableCredential, WrappedVerifiableCredential } from '@sphereon/ss
 
 import { Status } from '../../lib';
 import { EvaluationClientWrapper } from '../../lib/evaluation';
+import { SubmissionRequirementMatchType } from '../../lib/evaluation/core';
 import { InternalPresentationDefinitionV1, SSITypesBuilder } from '../../lib/types';
 import PexMessages from '../../lib/types/Messages';
-import { SubmissionRequirementMatchType } from '../../lib/evaluation/core';
 
 function getFile(path: string) {
   return JSON.parse(fs.readFileSync(path, 'utf-8'));
@@ -41,7 +41,7 @@ describe('selectFrom tests', () => {
           name: 'Submission of educational transcripts',
           rule: 'all',
           id: 0,
-          type: SubmissionRequirementMatchType.SubmissionRequirement
+          type: SubmissionRequirementMatchType.SubmissionRequirement,
         },
       ],
       verifiableCredential: [
@@ -455,7 +455,6 @@ describe('selectFrom tests', () => {
               // submission requirement from_nested has no name
               name: undefined,
               type: SubmissionRequirementMatchType.SubmissionRequirement,
-
             },
             {
               count: 2,
@@ -783,7 +782,7 @@ describe('selectFrom tests', () => {
         rule: 'pick',
         id: 0,
         type: SubmissionRequirementMatchType.SubmissionRequirement,
-        name: 'Eligibility to Work Proof'
+        name: 'Eligibility to Work Proof',
       },
     ]);
   });
@@ -811,7 +810,7 @@ describe('selectFrom tests', () => {
         rule: 'pick',
         type: SubmissionRequirementMatchType.SubmissionRequirement,
         name: 'Eligibility to Work Proof',
-        id: 0
+        id: 0,
       },
     ]);
     expect(result.errors?.length).toEqual(16);
@@ -955,7 +954,7 @@ describe('selectFrom tests', () => {
         rule: 'pick',
         max: 1,
         type: SubmissionRequirementMatchType.SubmissionRequirement,
-        id: 0
+        id: 0,
       },
     ]);
     expect(result.errors?.length).toEqual(16);

--- a/test/evaluation/selectFrom.spec.ts
+++ b/test/evaluation/selectFrom.spec.ts
@@ -7,6 +7,7 @@ import { Status } from '../../lib';
 import { EvaluationClientWrapper } from '../../lib/evaluation';
 import { InternalPresentationDefinitionV1, SSITypesBuilder } from '../../lib/types';
 import PexMessages from '../../lib/types/Messages';
+import { SubmissionRequirementMatchType } from '../../lib/evaluation/core';
 
 function getFile(path: string) {
   return JSON.parse(fs.readFileSync(path, 'utf-8'));
@@ -39,6 +40,8 @@ describe('selectFrom tests', () => {
           vc_path: ['$.verifiableCredential[0]', '$.verifiableCredential[1]', '$.verifiableCredential[2]'],
           name: 'Submission of educational transcripts',
           rule: 'all',
+          id: 0,
+          type: SubmissionRequirementMatchType.SubmissionRequirement
         },
       ],
       verifiableCredential: [
@@ -158,8 +161,10 @@ describe('selectFrom tests', () => {
           from: 'B',
           vc_path: ['$.verifiableCredential[0]', '$.verifiableCredential[1]'],
           min: 2,
-          name: 'Submission of educational transcripts',
+          name: 'Eligibility to Work Proof',
           rule: 'pick',
+          id: 0,
+          type: SubmissionRequirementMatchType.SubmissionRequirement,
         },
       ],
       verifiableCredential: [
@@ -248,8 +253,10 @@ describe('selectFrom tests', () => {
           from: 'B',
           vc_path: ['$.verifiableCredential[0]', '$.verifiableCredential[1]'],
           max: 2,
-          name: 'Submission of educational transcripts',
           rule: 'pick',
+          id: 0,
+          name: 'Eligibility to Work Proof',
+          type: SubmissionRequirementMatchType.SubmissionRequirement,
         },
       ],
       verifiableCredential: [
@@ -320,20 +327,28 @@ describe('selectFrom tests', () => {
             {
               from: 'A',
               vc_path: ['$.verifiableCredential[0]', '$.verifiableCredential[1]', '$.verifiableCredential[2]'],
-              name: 'Submission of educational transcripts',
               rule: 'all',
+              id: 0,
+              // submission requirement from_nested has no name
+              name: undefined,
+              type: SubmissionRequirementMatchType.SubmissionRequirement,
             },
             {
               count: 2,
               from: 'B',
               vc_path: ['$.verifiableCredential[1]', '$.verifiableCredential[2]'],
-              name: 'Submission of educational transcripts',
               rule: 'pick',
+              id: 1,
+              // submission requirement from_nested has no name
+              name: undefined,
+              type: SubmissionRequirementMatchType.SubmissionRequirement,
             },
           ],
           vc_path: [],
-          name: '32f54163-7166-48f1-93d8-ff217bdb0653',
           rule: 'all',
+          id: 0,
+          name: 'Confirm banking relationship or employment and residence proofs',
+          type: SubmissionRequirementMatchType.SubmissionRequirement,
         },
       ],
       verifiableCredential: [
@@ -435,21 +450,30 @@ describe('selectFrom tests', () => {
             {
               from: 'A',
               vc_path: ['$.verifiableCredential[0]', '$.verifiableCredential[1]', '$.verifiableCredential[2]'],
-              name: 'Submission of educational transcripts',
               rule: 'all',
+              id: 0,
+              // submission requirement from_nested has no name
+              name: undefined,
+              type: SubmissionRequirementMatchType.SubmissionRequirement,
+
             },
             {
               count: 2,
               from: 'B',
               vc_path: ['$.verifiableCredential[1]', '$.verifiableCredential[2]'],
-              name: 'Submission of educational transcripts',
               rule: 'pick',
+              id: 1,
+              // submission requirement from_nested has no name
+              name: undefined,
+              type: SubmissionRequirementMatchType.SubmissionRequirement,
             },
           ],
           vc_path: [],
           min: 1,
-          name: '32f54163-7166-48f1-93d8-ff217bdb0653',
           rule: 'pick',
+          id: 0,
+          name: 'Confirm banking relationship or employment and residence proofs',
+          type: SubmissionRequirementMatchType.SubmissionRequirement,
         },
       ],
       verifiableCredential: [
@@ -551,21 +575,29 @@ describe('selectFrom tests', () => {
             {
               from: 'A',
               vc_path: ['$.verifiableCredential[0]', '$.verifiableCredential[1]', '$.verifiableCredential[2]'],
-              name: 'Submission of educational transcripts',
               rule: 'all',
+              id: 0,
+              // submission requirement from_nested has no name
+              name: undefined,
+              type: SubmissionRequirementMatchType.SubmissionRequirement,
             },
             {
               count: 2,
               from: 'B',
               vc_path: ['$.verifiableCredential[1]', '$.verifiableCredential[2]'],
-              name: 'Submission of educational transcripts',
               rule: 'pick',
+              id: 1,
+              // submission requirement from_nested has no name
+              name: undefined,
+              type: SubmissionRequirementMatchType.SubmissionRequirement,
             },
           ],
           vc_path: [],
           max: 2,
-          name: '32f54163-7166-48f1-93d8-ff217bdb0653',
           rule: 'pick',
+          id: 0,
+          name: 'Confirm banking relationship or employment and residence proofs',
+          type: SubmissionRequirementMatchType.SubmissionRequirement,
         },
       ],
       verifiableCredential: [
@@ -748,8 +780,10 @@ describe('selectFrom tests', () => {
         from: 'B',
         vc_path: ['$.verifiableCredential[0]', '$.verifiableCredential[1]'],
         min: 3,
-        name: 'Submission of educational transcripts',
         rule: 'pick',
+        id: 0,
+        type: SubmissionRequirementMatchType.SubmissionRequirement,
+        name: 'Eligibility to Work Proof'
       },
     ]);
   });
@@ -774,8 +808,10 @@ describe('selectFrom tests', () => {
         from: 'B',
         vc_path: ['$.verifiableCredential[0]', '$.verifiableCredential[1]'],
         max: 1,
-        name: 'Submission of educational transcripts',
         rule: 'pick',
+        type: SubmissionRequirementMatchType.SubmissionRequirement,
+        name: 'Eligibility to Work Proof',
+        id: 0
       },
     ]);
     expect(result.errors?.length).toEqual(16);
@@ -847,22 +883,30 @@ describe('selectFrom tests', () => {
       from_nested: [
         {
           from: 'A',
-          name: 'Submission of educational transcripts',
           rule: Rules.All,
           vc_path: ['$.verifiableCredential[0]', '$.verifiableCredential[1]', '$.verifiableCredential[2]'],
+          id: 0,
+          // submission requirement from_nested has no name
+          name: undefined,
+          type: SubmissionRequirementMatchType.SubmissionRequirement,
         },
         {
           count: 2,
           from: 'B',
-          name: 'Submission of educational transcripts',
           rule: Rules.Pick,
           vc_path: ['$.verifiableCredential[1]', '$.verifiableCredential[2]'],
+          id: 1,
+          // submission requirement from_nested has no name
+          name: undefined,
+          type: SubmissionRequirementMatchType.SubmissionRequirement,
         },
       ],
       min: 1,
-      name: '32f54163-7166-48f1-93d8-ff217bdb0653',
+      name: 'Confirm banking relationship or employment and residence proofs',
       rule: Rules.Pick,
       vc_path: [],
+      id: 0,
+      type: SubmissionRequirementMatchType.SubmissionRequirement,
     });
   });
 
@@ -888,21 +932,30 @@ describe('selectFrom tests', () => {
           {
             from: 'A',
             vc_path: ['$.verifiableCredential[0]', '$.verifiableCredential[1]', '$.verifiableCredential[2]'],
-            name: 'Submission of educational transcripts',
             rule: 'all',
+            id: 0,
+            // submission requirement from_nested has no name
+            name: undefined,
+            type: SubmissionRequirementMatchType.SubmissionRequirement,
           },
           {
             count: 2,
             from: 'B',
             vc_path: ['$.verifiableCredential[1]', '$.verifiableCredential[2]'],
-            name: 'Submission of educational transcripts',
             rule: 'pick',
+            id: 1,
+            // submission requirement from_nested has no name
+            name: undefined,
+            type: SubmissionRequirementMatchType.SubmissionRequirement,
           },
         ],
         vc_path: [],
-        name: '32f54163-7166-48f1-93d8-ff217bdb0653',
+        // submission requirement name
+        name: 'Confirm banking relationship or employment and residence proofs',
         rule: 'pick',
         max: 1,
+        type: SubmissionRequirementMatchType.SubmissionRequirement,
+        id: 0
       },
     ]);
     expect(result.errors?.length).toEqual(16);
@@ -922,6 +975,8 @@ describe('selectFrom tests', () => {
     expect(result!.matches![0]!.name).toEqual("EU Driver's License");
     expect(result!.matches![0]).toEqual({
       name: "EU Driver's License",
+      id: 'citizenship_input_1',
+      type: SubmissionRequirementMatchType.InputDescriptor,
       rule: 'all',
       vc_path: ['$.verifiableCredential[0]'],
     });
@@ -939,6 +994,6 @@ describe('selectFrom tests', () => {
       limitDisclosureSignatureSuites: LIMIT_DISCLOSURE_SIGNATURE_SUITES,
     });
     expect(result!.errors!.length).toEqual(0);
-    expect(result!.matches![0]!.name).toEqual("EU Driver's License");
+    expect(result!.matches![0]!.name).toEqual("Name on driver's license");
   });
 });

--- a/test/thirdParty/Animo.spec.ts
+++ b/test/thirdParty/Animo.spec.ts
@@ -2,6 +2,7 @@ import { Rules } from '@sphereon/pex-models';
 import { W3CVerifiableCredential } from '@sphereon/ssi-types';
 
 import { IPresentationDefinition, PEX, Status } from '../../lib';
+import { SubmissionRequirementMatchType } from '../../lib/evaluation/core';
 
 describe('evaluate animo tests', () => {
   it('should pass with 2 VCs and 2 IDs', () => {
@@ -133,10 +134,28 @@ describe('evaluate animo tests', () => {
     const pex: PEX = new PEX();
     const result = pex.selectFrom(pd, vcs);
     expect(result.areRequiredCredentialsPresent).toEqual(Status.INFO);
-    expect(result.matches?.length).toEqual(2);
-    expect(new Set(result.matches?.map((value) => value.name)).size).toEqual(2);
-    expect(result.matches?.map((value) => value.name).indexOf('c2834d0e-3c95-4721-b21a-40e3d7ea2549')).toBeGreaterThanOrEqual(0);
-    expect(result.matches?.map((value) => value.name).indexOf('c2834d0e-3c95-4721-b21a-40e3d7ea25434')).toBeGreaterThanOrEqual(0);
+    expect(result.matches).toEqual([{
+      count: 1,
+      from: "A",
+      id: 0,
+      name: undefined,
+      rule: "pick",
+      type: SubmissionRequirementMatchType.SubmissionRequirement,
+      vc_path: [
+        "$.verifiableCredential[0]",
+      ],
+    },
+    {
+      count: 1,
+      from: "B",
+      id: 1,
+      name: undefined,
+      rule: "pick",
+      type: SubmissionRequirementMatchType.SubmissionRequirement,
+      vc_path: [
+        "$.verifiableCredential[1]",
+      ],
+    },])
   });
 
   const vcs: W3CVerifiableCredential[] = [

--- a/test/thirdParty/Animo.spec.ts
+++ b/test/thirdParty/Animo.spec.ts
@@ -134,28 +134,26 @@ describe('evaluate animo tests', () => {
     const pex: PEX = new PEX();
     const result = pex.selectFrom(pd, vcs);
     expect(result.areRequiredCredentialsPresent).toEqual(Status.INFO);
-    expect(result.matches).toEqual([{
-      count: 1,
-      from: "A",
-      id: 0,
-      name: undefined,
-      rule: "pick",
-      type: SubmissionRequirementMatchType.SubmissionRequirement,
-      vc_path: [
-        "$.verifiableCredential[0]",
-      ],
-    },
-    {
-      count: 1,
-      from: "B",
-      id: 1,
-      name: undefined,
-      rule: "pick",
-      type: SubmissionRequirementMatchType.SubmissionRequirement,
-      vc_path: [
-        "$.verifiableCredential[1]",
-      ],
-    },])
+    expect(result.matches).toEqual([
+      {
+        count: 1,
+        from: 'A',
+        id: 0,
+        name: undefined,
+        rule: 'pick',
+        type: SubmissionRequirementMatchType.SubmissionRequirement,
+        vc_path: ['$.verifiableCredential[0]'],
+      },
+      {
+        count: 1,
+        from: 'B',
+        id: 1,
+        name: undefined,
+        rule: 'pick',
+        type: SubmissionRequirementMatchType.SubmissionRequirement,
+        vc_path: ['$.verifiableCredential[1]'],
+      },
+    ]);
   });
 
   const vcs: W3CVerifiableCredential[] = [

--- a/test/thirdParty/Gataca.spec.ts
+++ b/test/thirdParty/Gataca.spec.ts
@@ -2,9 +2,9 @@ import { PresentationDefinitionV1 } from '@sphereon/pex-models';
 import { IPresentation, IProofType, IVerifiableCredential } from '@sphereon/ssi-types';
 
 import { PEX, PEXv1, Status } from '../../lib';
+import { SubmissionRequirementMatchType } from '../../lib/evaluation/core';
 import { GatacaPresentationDefinition } from '../test_data/gataca/gatacaPresentationDefinition';
 import { GatacaSelectedCredentials } from '../test_data/gataca/gatacaSelectedCredentials';
-import { SubmissionRequirementMatchType } from '../../lib/evaluation/core';
 
 const LIMIT_DISCLOSURE_SIGNATURE_SUITES = [IProofType.BbsBlsSignatureProof2020];
 
@@ -30,7 +30,7 @@ describe('evaluate gataca tests', () => {
         from: 'mandatory',
         vc_path: ['$.verifiableCredential[0]'],
         id: 0,
-        name: "Mandatory data",
+        name: 'Mandatory data',
         type: SubmissionRequirementMatchType.SubmissionRequirement,
       },
       {
@@ -38,7 +38,7 @@ describe('evaluate gataca tests', () => {
         from: 'optional',
         vc_path: ['$.verifiableCredential[1]'],
         id: 1,
-        name: "Optional data",
+        name: 'Optional data',
         type: SubmissionRequirementMatchType.SubmissionRequirement,
       },
     ]);
@@ -108,7 +108,7 @@ describe('evaluate gataca tests', () => {
         from: 'mandatory',
         vc_path: ['$.verifiableCredential[0]'],
         id: 0,
-        name: "Mandatory data",
+        name: 'Mandatory data',
         type: SubmissionRequirementMatchType.SubmissionRequirement,
       },
       {
@@ -116,7 +116,7 @@ describe('evaluate gataca tests', () => {
         from: 'optional',
         vc_path: ['$.verifiableCredential[1]'],
         id: 1,
-        name: "Optional data",
+        name: 'Optional data',
         type: SubmissionRequirementMatchType.SubmissionRequirement,
       },
     ]);

--- a/test/thirdParty/Gataca.spec.ts
+++ b/test/thirdParty/Gataca.spec.ts
@@ -4,6 +4,7 @@ import { IPresentation, IProofType, IVerifiableCredential } from '@sphereon/ssi-
 import { PEX, PEXv1, Status } from '../../lib';
 import { GatacaPresentationDefinition } from '../test_data/gataca/gatacaPresentationDefinition';
 import { GatacaSelectedCredentials } from '../test_data/gataca/gatacaSelectedCredentials';
+import { SubmissionRequirementMatchType } from '../../lib/evaluation/core';
 
 const LIMIT_DISCLOSURE_SIGNATURE_SUITES = [IProofType.BbsBlsSignatureProof2020];
 
@@ -28,13 +29,17 @@ describe('evaluate gataca tests', () => {
         rule: 'all',
         from: 'mandatory',
         vc_path: ['$.verifiableCredential[0]'],
-        name: 'emailCredential',
+        id: 0,
+        name: "Mandatory data",
+        type: SubmissionRequirementMatchType.SubmissionRequirement,
       },
       {
         rule: 'pick',
         from: 'optional',
         vc_path: ['$.verifiableCredential[1]'],
-        name: 'transcriptOfRecordsCredential',
+        id: 1,
+        name: "Optional data",
+        type: SubmissionRequirementMatchType.SubmissionRequirement,
       },
     ]);
     expect(result.verifiableCredential?.length).toEqual(2);
@@ -102,13 +107,17 @@ describe('evaluate gataca tests', () => {
         rule: 'all',
         from: 'mandatory',
         vc_path: ['$.verifiableCredential[0]'],
-        name: 'emailCredential',
+        id: 0,
+        name: "Mandatory data",
+        type: SubmissionRequirementMatchType.SubmissionRequirement,
       },
       {
         rule: 'pick',
         from: 'optional',
         vc_path: ['$.verifiableCredential[1]'],
-        name: 'transcriptOfRecordsCredential',
+        id: 1,
+        name: "Optional data",
+        type: SubmissionRequirementMatchType.SubmissionRequirement,
       },
     ]);
     expect(result.verifiableCredential?.length).toEqual(2);

--- a/test/thirdParty/JGiter.spec.ts
+++ b/test/thirdParty/JGiter.spec.ts
@@ -582,21 +582,21 @@ describe('evaluate JGiter tests', () => {
         rule: Rules.All,
         vc_path: ['$.verifiableCredential[0]'],
         id: 'identity_input',
-        type: SubmissionRequirementMatchType.InputDescriptor
+        type: SubmissionRequirementMatchType.InputDescriptor,
       },
       {
         name: 'Subject name input',
         rule: Rules.All,
         vc_path: ['$.verifiableCredential[0]'],
         id: 'name_input',
-        type: SubmissionRequirementMatchType.InputDescriptor
+        type: SubmissionRequirementMatchType.InputDescriptor,
       },
       {
         name: 'Admin role input',
         rule: Rules.All,
         vc_path: ['$.verifiableCredential[1]'],
         id: 'role_input',
-        type: SubmissionRequirementMatchType.InputDescriptor
+        type: SubmissionRequirementMatchType.InputDescriptor,
       },
     ]);
     expect(resultSelectFrom.verifiableCredential?.length).toEqual(2);

--- a/test/thirdParty/JGiter.spec.ts
+++ b/test/thirdParty/JGiter.spec.ts
@@ -3,6 +3,7 @@ import { IPresentation, IProofType, IVerifiableCredential } from '@sphereon/ssi-
 
 import { EvaluationResults, PEX, Status } from '../../lib';
 import { PresentationEvaluationResults } from '../../lib/evaluation';
+import { SubmissionRequirementMatchType } from '../../lib/evaluation/core';
 
 const LIMIT_DISCLOSURE_SIGNATURE_SUITES = [IProofType.BbsBlsSignatureProof2020];
 
@@ -580,16 +581,22 @@ describe('evaluate JGiter tests', () => {
         name: 'Subject identity input',
         rule: Rules.All,
         vc_path: ['$.verifiableCredential[0]'],
+        id: 'identity_input',
+        type: SubmissionRequirementMatchType.InputDescriptor
       },
       {
         name: 'Subject name input',
         rule: Rules.All,
         vc_path: ['$.verifiableCredential[0]'],
+        id: 'name_input',
+        type: SubmissionRequirementMatchType.InputDescriptor
       },
       {
         name: 'Admin role input',
         rule: Rules.All,
         vc_path: ['$.verifiableCredential[1]'],
+        id: 'role_input',
+        type: SubmissionRequirementMatchType.InputDescriptor
       },
     ]);
     expect(resultSelectFrom.verifiableCredential?.length).toEqual(2);


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Introduces a new `id` and `type` property on the `SubmissionRequirementMatch` interface that allows better matching of a match object to the related input_descriptor or submission_requirement.

If the match is for an input descriptor (in case there are no submission_requirements) the `type` property will be `SubmissionRequirementMatchType.InputDescriptor` and the `id` property will be the id of the input descriptor

I the match is for a submission requirement, the `type` property will be `SubmissionRequirementMatchType.SubmissionRequirement` and the `id` property will be the index of the submission requirement in the `submission_requirements` array (this is the only unique thing I could find to link back to the submission requirement entry, there is no required id field or something). This also works for nested submission requirements. In this case the outer match `id` is the outer index in the submission requirement, and the inner match `id` is the index within the `from_nested` array (this can recurse endlessly).

Although adding these properties is not a breaking change, I did change the behaviour of the `name` property as well. Currently this was set to the name or id of one of the input descriptors, even if the match is for a submission requirement, which leads to confusion and doesn't make sense IMO. So if the match is for a submission requirement (for input descriptor behaviour stays the same) I now updated that to be either the name of the submission requirement, or undefined if there submission_requirement has no name. You can use the `id` property to locate the submission requirement associated with the match.

One thing we lose here (but basically wasn't present before as well) is that you now don't know which input descriptor(s) the credentials in a submission requirement match are from. So if a group "E" can either accept a cred from input descriptor "A" or "B" you now just know that the credentials in the list match group "E", not which input descriptor they came from

I see this as a great additional feature for a follow PR (it will be non-breaking extra metadata, but should somehow be linked to the vc_paths, as there can be vcs from different input descriptors in the match list)

This fixes #116 as well as #161 (on the PEX level, there will be changes required in Credo as well)

The changes in tests mostly come from now also expecting the new properties, the change in code are quite minimal