### PR TITLE
fix: do not set hash alg as alg

### DIFF
--- a/lib/PEX.ts
+++ b/lib/PEX.ts
@@ -546,7 +546,6 @@ export class PEX {
         // alg MUST be set by the signer
         header: {
           typ: 'kb+jwt',
-          alg: hashAlg,
         },
         // aud MUST be set by the signer or provided by e.g. SIOP/OpenID4VP lib
         payload: {


### PR DESCRIPTION
As I commented in #166, setting the alg of the kb-jwt to hashAlg is not correct (signing vs hashing alg)