### PR TITLE
fix: allow optional field, add extra alg types

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,8 +16,6 @@ jobs:
       with:
         fetch-depth: 0
     - uses: pnpm/action-setup@v4
-      with:
-        version: 8
     - name: Use Node.js
       uses: actions/setup-node@v4
       with:

--- a/lib/types/Internal.types.ts
+++ b/lib/types/Internal.types.ts
@@ -92,8 +92,8 @@ export class InternalPresentationDefinitionV2 implements PresentationDefinitionV
 export interface DiscoveredVersion {
   version?: PEVersion;
   error?: string;
-  v1Errors?: any
-  v2Errors?: any
+  v1Errors?: Record<string, unknown>;
+  v2Errors?: Record<string, unknown>;
 }
 
 export type IPresentationDefinition = PresentationDefinitionV1 | PresentationDefinitionV2;

--- a/lib/types/Internal.types.ts
+++ b/lib/types/Internal.types.ts
@@ -92,6 +92,8 @@ export class InternalPresentationDefinitionV2 implements PresentationDefinitionV
 export interface DiscoveredVersion {
   version?: PEVersion;
   error?: string;
+  v1Errors?: any
+  v2Errors?: any
 }
 
 export type IPresentationDefinition = PresentationDefinitionV1 | PresentationDefinitionV2;

--- a/lib/types/SSITypesBuilder.ts
+++ b/lib/types/SSITypesBuilder.ts
@@ -63,7 +63,11 @@ export class SSITypesBuilder {
   static toInternalPresentationDefinition(presentationDefinition: IPresentationDefinition): IInternalPresentationDefinition {
     const presentationDefinitionCopy: IPresentationDefinition = JSON.parse(JSON.stringify(presentationDefinition));
     const versionResult: DiscoveredVersion = definitionVersionDiscovery(presentationDefinitionCopy);
-    if (versionResult.error) throw versionResult.error;
+    if (versionResult.error) {
+      throw new Error(
+        `${versionResult.error} \nv1 errors:\n${JSON.stringify(versionResult.v1Errors, null, 2)} \n\nv2 errors:\n${JSON.stringify(versionResult.v2Errors, null, 2)}`,
+      );
+    }
     if (versionResult.version == PEVersion.v1) {
       return SSITypesBuilder.modelEntityToInternalPresentationDefinitionV1(presentationDefinitionCopy as PresentationDefinitionV1);
     }

--- a/lib/utils/VCUtils.ts
+++ b/lib/utils/VCUtils.ts
@@ -35,14 +35,26 @@ export function definitionVersionDiscovery(presentationDefinition: IPresentation
   JsonPathUtils.changePropertyNameRecursively(presentationDefinitionCopy, '_enum', 'enum');
   const data = { presentation_definition: presentationDefinitionCopy };
   let result = validatePDv2(data);
+
   if (result) {
     return { version: PEVersion.v2 };
   }
+  // Errors are added to the validation method, but not typed correctly
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  const v2Errors = validatePDv2.errors;
+
   result = validatePDv1(data);
   if (result) {
     return { version: PEVersion.v1 };
   }
-  return { error: 'This is not a valid PresentationDefinition' };
+
+  // Errors are added to the validation method, but not typed correctly
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  const v1Errors = validatePDv1.errors;
+
+  return { error: 'This is not a valid PresentationDefinition', v1Errors, v2Errors };
 }
 
 export function uniformDIDMethods(dids?: string[], opts?: { removePrefix: 'did:' }) {

--- a/lib/validation/core/jwtAlgos.ts
+++ b/lib/validation/core/jwtAlgos.ts
@@ -11,6 +11,8 @@ export class JwtAlgos {
       'ES256',
       'ES384',
       'ES512',
+      'ES256K',
+      'EdDSA',
       'PS256',
       'PS384',
       'PS512',

--- a/lib/validation/core/ldpTypes.ts
+++ b/lib/validation/core/ldpTypes.ts
@@ -4,6 +4,7 @@ export class LdpTypes {
     return [
       'Ed25519VerificationKey2018',
       'Ed25519Signature2018',
+      'Ed25519Signature2020',
       'RsaSignature2018',
       'EcdsaSecp256k1Signature2019',
       'EcdsaSecp256k1RecoverySignature2020',

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "typings": "dist/main/index.d.ts",
   "repository": "https://github.com/Sphereon-Opensource/pex.git",
   "license": "Apache-2.0",
+  "packageManager": "pnpm@8.15.9+sha256.daa27a0b541bc635323ff96c2ded995467ff9fe6d69ff67021558aa9ad9dcc36",
   "keywords": [
     "SSI",
     "Presentation Exchange",

--- a/resources/presentation_definition_v2.schema.json
+++ b/resources/presentation_definition_v2.schema.json
@@ -351,6 +351,9 @@
                 "type": "string"
               }
             },
+            "optional": {
+              "type": "boolean"
+            },
             "purpose": {
               "type": "string"
             },
@@ -379,6 +382,9 @@
               "items": {
                 "type": "string"
               }
+            },
+            "optional": {
+              "type": "boolean"
             },
             "purpose": {
               "type": "string"

--- a/test/PEX.spec.ts
+++ b/test/PEX.spec.ts
@@ -769,6 +769,19 @@ describe('evaluate', () => {
     expect(result).toEqual([{ message: 'ok', status: 'info', tag: 'root' }]);
   });
 
+  it.only('allows optional value in field definition', () => {
+    const pdSchema: PresentationDefinitionV2 = getFileAsJson('./test/resources/pd_optional_values.json').presentation_definition;
+    const result = PEXv2.validateDefinition(pdSchema);
+
+    expect(result).toEqual([
+      {
+        tag: 'root',
+        status: 'info',
+        message: 'ok',
+      },
+    ]);
+  });
+
   it('correct handles presentation definition with const values in filter', () => {
     const pdSchema: PresentationDefinitionV2 = getFileAsJson('./test/resources/pd_const_values.json').presentation_definition;
     const result = PEXv2.validateDefinition(pdSchema);

--- a/test/evaluation/selectFrom.spec.ts
+++ b/test/evaluation/selectFrom.spec.ts
@@ -1029,8 +1029,7 @@ describe('selectFrom tests', () => {
     pex.evaluateCredentials(pd, result.verifiableCredential!);
     const presentationResult = pex.presentationFrom(pd, result.verifiableCredential!);
     const cred = await SDJwt.fromEncode(presentationResult.presentations[1].compactSdJwtVc, hasher);
-    const claims = await cred.getClaims(hasher);
-    console.log(claims);
+    await cred.getClaims(hasher);
     expect(presentationResult).toBeDefined();
     // TODO finish test
   });

--- a/test/resources/pd_optional_values.json
+++ b/test/resources/pd_optional_values.json
@@ -1,0 +1,56 @@
+{
+  "presentation_definition": {
+    "id": "90acec0e-1bc7-4769-ab43-02995d7582c4",
+    "format": {
+      "jwt_vp_json": {
+        "alg": ["EdDSA", "ES256K", "PS256", "ES256"]
+      },
+      "jwt_vc_json": {
+        "alg": ["EdDSA", "ES256K", "PS256", "ES256"]
+      },
+      "ldp_vp": {
+        "proof_type": ["Ed25519Signature2018", "Ed25519Signature2020", "JsonWebSignature2020"]
+      },
+      "ldp_vc": {
+        "proof_type": ["Ed25519Signature2018", "Ed25519Signature2020", "JsonWebSignature2020"]
+      },
+      "jwt_vc": {
+        "alg": ["ES256"]
+      },
+      "jwt_vp": {
+        "alg": ["ES256"]
+      }
+    },
+    "input_descriptors": [
+      {
+        "id": "be2ca7fc-71c2-40d8-92e0-64b407b26b1a",
+        "format": {
+          "jwt_vc_json": {
+            "alg": ["ES256", "ES256K", "PS256", "EdDSA"]
+          },
+          "jwt_vp_json": {
+            "alg": ["ES256", "ES256K", "PS256", "EdDSA"]
+          },
+          "jwt_vc": {
+            "alg": ["ES256"]
+          },
+          "jwt_vp": {
+            "alg": ["ES256"]
+          }
+        },
+        "constraints": {
+          "fields": [
+            {
+              "path": ["$.vc.type", "$.type"],
+              "optional": true,
+              "filter": {
+                "type": "string",
+                "pattern": "OpenBadgeCredential"
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
This PR does three things:
- Allow `optional` in the v2 schema (per @cykoder's [comment](https://github.com/Sphereon-Opensource/PEX/issues/150#issuecomment-2099418202))
- Add extra alg values ( i don't think we should be matching these at all, now evertime a new value is used it will break)
- Return the errors from the PD validation, as it's now very hard to know what is wrong about the PD (i always add this code manually in node_modules build)

Discovered when trying to handle a presentation request with PD from DanubeTech universal verifier (https://oid4vp.univerifier.io/)