### PR TITLE
chore: VDX-339 improve error handling definitionVersionDiscovery

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -2,5 +2,5 @@ module.exports = {
     transform: {'^.+\\.ts?$': 'ts-jest'},
     testEnvironment: 'node',
     testRegex: '/test/.*\\.(test|spec)?\\.ts$',
-    moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node']
+    moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node', 'd.ts']
 };

--- a/lib/types/Internal.types.ts
+++ b/lib/types/Internal.types.ts
@@ -8,6 +8,8 @@ import {
 } from '@sphereon/pex-models';
 import { IVerifiableCredential, IVerifiablePresentation } from '@sphereon/ssi-types';
 
+import { ValidationError } from '../validation/validators';
+
 export interface InputDescriptorWithIndex {
   inputDescriptorIndex: number;
   inputDescriptor: InputDescriptorV1 | InputDescriptorV2;
@@ -92,8 +94,8 @@ export class InternalPresentationDefinitionV2 implements PresentationDefinitionV
 export interface DiscoveredVersion {
   version?: PEVersion;
   error?: string;
-  v1Errors?: Record<string, unknown>;
-  v2Errors?: Record<string, unknown>;
+  v1Errors?: Array<ValidationError>;
+  v2Errors?: Array<ValidationError>;
 }
 
 export type IPresentationDefinition = PresentationDefinitionV1 | PresentationDefinitionV2;

--- a/lib/validation/validatePDv1.d.ts
+++ b/lib/validation/validatePDv1.d.ts
@@ -1,0 +1,6 @@
+import type { ValidateFunction, ValidationError } from './validators';
+
+declare module './validatePDv1.js' {
+  const validate: ValidateFunction & { errors?: ValidationError[] | null };
+  export default validate;
+}

--- a/lib/validation/validatePDv2.d.ts
+++ b/lib/validation/validatePDv2.d.ts
@@ -1,0 +1,6 @@
+import type { ValidateFunction, ValidationError } from './validators';
+
+declare module './validatePDv2.js' {
+  const validate: ValidateFunction & { errors?: ValidationError[] | null };
+  export default validate;
+}

--- a/lib/validation/validators.d.ts
+++ b/lib/validation/validators.d.ts
@@ -1,0 +1,71 @@
+export interface ValidateFunction {
+  (data: unknown): boolean;
+  errors?: ValidationError[];
+}
+
+export type ValidationParentSchema = {
+  type?: string | string[];
+  properties?: {
+    [key: string]: {
+      type?: string;
+      enum?: string[];
+      items?: {
+        type?: string;
+        $ref?: string;
+      };
+      properties?: Record<string, unknown>;
+      required?: string[];
+      additionalProperties?: boolean;
+      $ref?: string;
+    };
+  };
+  required?: string[];
+  additionalProperties?: boolean;
+  items?: {
+    type?: string;
+    $ref?: string;
+  };
+};
+
+export type ValidationData = {
+  id?: string;
+  name?: string;
+  purpose?: string;
+  constraints?: {
+    limit_disclosure?: string;
+    fields?: Array<{
+      path?: string[];
+      purpose?: string;
+      filter?: {
+        type?: string;
+        pattern?: string;
+      };
+    }>;
+  };
+  schema?: Array<{
+    uri?: string;
+  }>;
+  [key: string]: unknown;
+};
+
+export type ValidationError = {
+  instancePath: string;
+  schemaPath: string;
+  keyword: string;
+  params: {
+    type?: string | string[];
+    limit?: number;
+    comparison?: string;
+    missingProperty?: string;
+    additionalProperty?: string;
+    propertyName?: string;
+    i?: number;
+    j?: number;
+    allowedValues?: string[] | readonly string[];
+    passingSchemas?: number | number[];
+  };
+  message: string;
+  schema: boolean | ValidationParentSchema;
+  parentSchema: ValidationParentSchema;
+  data: ValidationData;
+};

--- a/lib/validation/validators.d.ts
+++ b/lib/validation/validators.d.ts
@@ -1,5 +1,8 @@
+import { PresentationDefinitionV1, PresentationDefinitionV2 } from '@sphereon/pex-models';
+
 export interface ValidateFunction {
   (data: unknown): boolean;
+
   errors?: ValidationError[];
 }
 
@@ -27,27 +30,6 @@ export type ValidationParentSchema = {
   };
 };
 
-export type ValidationData = {
-  id?: string;
-  name?: string;
-  purpose?: string;
-  constraints?: {
-    limit_disclosure?: string;
-    fields?: Array<{
-      path?: string[];
-      purpose?: string;
-      filter?: {
-        type?: string;
-        pattern?: string;
-      };
-    }>;
-  };
-  schema?: Array<{
-    uri?: string;
-  }>;
-  [key: string]: unknown;
-};
-
 export type ValidationError = {
   instancePath: string;
   schemaPath: string;
@@ -67,5 +49,5 @@ export type ValidationError = {
   message: string;
   schema: boolean | ValidationParentSchema;
   parentSchema: ValidationParentSchema;
-  data: ValidationData;
+  data: PresentationDefinitionV1 | PresentationDefinitionV2;
 };

--- a/test/PEXv2.spec.ts
+++ b/test/PEXv2.spec.ts
@@ -325,6 +325,23 @@ describe('evaluate', () => {
     expect(result!.areRequiredCredentialsPresent).toBe('info');
   });
 
+  it('Evaluate selectFrom should fail', () => {
+    const pd: PresentationDefinitionV2 = getPresentationDefinitionV2_1();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (pd as any).input_descriptors = undefined;
+    const result1 = PEX.definitionVersionDiscovery(pd);
+    expect(result1.v1Errors?.length).toBe(2);
+    expect(result1.v2Errors?.length).toBe(1);
+    expect(() => PEX.validateDefinition(pd)).toThrow(
+      'This is not a valid PresentationDefinition\n' +
+        'Version 1 validation errors:\n' +
+        "  /presentation_definition: must have required property 'input_descriptors'\n" +
+        '  /presentation_definition: must NOT have additional properties (frame)\n' +
+        'Version 2 validation errors:\n' +
+        "  /presentation_definition: must have required property 'input_descriptors'",
+    );
+  });
+
   it("should throw error if proofOptions doesn't have a type with v2 pd", async () => {
     const pdSchema = getFile('./test/dif_pe_examples/pdV2/vc_expiration(corrected).json');
     const vpSimple = getFile('./test/dif_pe_examples/vp/vp_general.json') as IVerifiablePresentation;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -38,7 +38,11 @@
     "lib": [
       "es7", "dom"
     ],*/
-    "types": ["jest", "node"]
+    "types": ["jest", "node"],
+    "typeRoots": [
+      "./node_modules/@types",
+      "./src/validation"
+    ]
   },
   "include": [
     "declarations.d.ts",


### PR DESCRIPTION
I am not a fan of returning Record<string, unknown> as error type. You still can't see what's coming back.
I had types generated for ValidationError