### PR TITLE
fix: support generating submission for mdoc

### DIFF
--- a/lib/utils/formatMap.ts
+++ b/lib/utils/formatMap.ts
@@ -24,4 +24,5 @@ const vcVpFormatMap = {
   ldp_vc: 'ldp_vp',
   jwt_vc: 'jwt_vp',
   'vc+sd-jwt': 'vc+sd-jwt',
+  mso_mdoc: 'mso_mdoc',
 } as const;

--- a/test/Mdoc.spec.ts
+++ b/test/Mdoc.spec.ts
@@ -159,6 +159,31 @@ describe('evaluate mdoc', () => {
     });
   });
 
+  it('evaluatePresentation with mso_mdoc format generating a submission', async () => {
+    const presentationDefinition = getPresentationDefinitionV2();
+    const evaluateResults = pex.evaluatePresentation(presentationDefinition, [mdocBase64UrlUniversityPresentation], {
+      generatePresentationSubmission: true,
+    });
+
+    expect(evaluateResults).toEqual({
+      presentations: [mdocBase64UrlUniversityPresentation],
+      areRequiredCredentialsPresent: Status.INFO,
+      warnings: [],
+      errors: [],
+      value: {
+        definition_id: presentationDefinition.id,
+        descriptor_map: [
+          {
+            format: 'mso_mdoc',
+            id: 'org.eu.university',
+            path: '$[0]',
+          },
+        ],
+        id: expect.any(String),
+      },
+    });
+  });
+
   it('evaluatePresentation with both mso_mdoc and vc+sd-jwt format', async () => {
     const presentationDefinition = getPresentationDefinitionV2(true);
     const submission = {


### PR DESCRIPTION
small issue found while integrating into oid4vp. It needed this mapping to allow generating the submission for mdocs as well